### PR TITLE
fix(processor): fix enum codegen

### DIFF
--- a/packages/processor/generated/100/common.ts
+++ b/packages/processor/generated/100/common.ts
@@ -333,10 +333,7 @@ export const cfChainsBtcScriptPubkey = z.union([
   z.object({ __kind: z.literal('P2WPKH'), value: hexString }),
   z.object({ __kind: z.literal('P2WSH'), value: hexString }),
   z.object({ __kind: z.literal('Taproot'), value: hexString }),
-  z.object({
-    __kind: z.literal('OtherSegwit'),
-    value: z.object({ version: z.number(), program: hexString }),
-  }),
+  z.object({ __kind: z.literal('OtherSegwit'), version: z.number(), program: hexString }),
 ]);
 
 export const cfChainsAddressEncodedAddress = z.union([
@@ -356,11 +353,9 @@ export const cfChainsCcmChannelMetadata = z.object({
 export const cfChainsSwapOrigin = z.union([
   z.object({
     __kind: z.literal('DepositChannel'),
-    value: z.object({
-      depositAddress: cfChainsAddressEncodedAddress,
-      channelId: numberOrHex,
-      depositBlockHeight: numberOrHex,
-    }),
+    depositAddress: cfChainsAddressEncodedAddress,
+    channelId: numberOrHex,
+    depositBlockHeight: numberOrHex,
   }),
   z.object({ __kind: z.literal('Vault'), txHash: hexString }),
 ]);

--- a/packages/processor/generated/111/common.ts
+++ b/packages/processor/generated/111/common.ts
@@ -33,10 +33,7 @@ export const cfChainsBtcScriptPubkey = z.union([
   z.object({ __kind: z.literal('P2WPKH'), value: hexString }),
   z.object({ __kind: z.literal('P2WSH'), value: hexString }),
   z.object({ __kind: z.literal('Taproot'), value: hexString }),
-  z.object({
-    __kind: z.literal('OtherSegwit'),
-    value: z.object({ version: z.number(), program: hexString }),
-  }),
+  z.object({ __kind: z.literal('OtherSegwit'), version: z.number(), program: hexString }),
 ]);
 
 export const cfPrimitivesChainsAssetsAnyAsset = simpleEnum(['Eth', 'Flip', 'Usdc', 'Dot', 'Btc']);

--- a/packages/processor/generated/120/common.ts
+++ b/packages/processor/generated/120/common.ts
@@ -116,10 +116,7 @@ export const cfChainsBtcScriptPubkey = z.union([
   z.object({ __kind: z.literal('P2WPKH'), value: hexString }),
   z.object({ __kind: z.literal('P2WSH'), value: hexString }),
   z.object({ __kind: z.literal('Taproot'), value: hexString }),
-  z.object({
-    __kind: z.literal('OtherSegwit'),
-    value: z.object({ version: z.number(), program: hexString }),
-  }),
+  z.object({ __kind: z.literal('OtherSegwit'), version: z.number(), program: hexString }),
 ]);
 
 export const cfChainsAddressForeignChainAddress = z.union([
@@ -147,7 +144,8 @@ export const palletCfIngressEgressDepositAction = z.union([
   z.object({ __kind: z.literal('LiquidityProvision'), lpAccount: accountId }),
   z.object({
     __kind: z.literal('CcmTransfer'),
-    value: z.object({ principalSwapId: numberOrHex.nullish(), gasSwapId: numberOrHex.nullish() }),
+    principalSwapId: numberOrHex.nullish(),
+    gasSwapId: numberOrHex.nullish(),
   }),
   z.object({ __kind: z.literal('NoAction') }),
 ]);

--- a/packages/processor/generated/131/common.ts
+++ b/packages/processor/generated/131/common.ts
@@ -211,11 +211,9 @@ export const cfChainsCcmChannelMetadata = z.object({
 export const cfChainsSwapOrigin = z.union([
   z.object({
     __kind: z.literal('DepositChannel'),
-    value: z.object({
-      depositAddress: cfChainsAddressEncodedAddress,
-      channelId: numberOrHex,
-      depositBlockHeight: numberOrHex,
-    }),
+    depositAddress: cfChainsAddressEncodedAddress,
+    channelId: numberOrHex,
+    depositBlockHeight: numberOrHex,
   }),
   z.object({ __kind: z.literal('Vault'), txHash: hexString }),
 ]);
@@ -226,10 +224,7 @@ export const cfChainsBtcScriptPubkey = z.union([
   z.object({ __kind: z.literal('P2WPKH'), value: hexString }),
   z.object({ __kind: z.literal('P2WSH'), value: hexString }),
   z.object({ __kind: z.literal('Taproot'), value: hexString }),
-  z.object({
-    __kind: z.literal('OtherSegwit'),
-    value: z.object({ version: z.number(), program: hexString }),
-  }),
+  z.object({ __kind: z.literal('OtherSegwit'), version: z.number(), program: hexString }),
 ]);
 
 export const cfChainsAddressForeignChainAddress = z.union([
@@ -265,7 +260,8 @@ export const palletCfIngressEgressDepositAction = z.union([
   z.object({ __kind: z.literal('LiquidityProvision'), lpAccount: accountId }),
   z.object({
     __kind: z.literal('CcmTransfer'),
-    value: z.object({ principalSwapId: numberOrHex.nullish(), gasSwapId: numberOrHex.nullish() }),
+    principalSwapId: numberOrHex.nullish(),
+    gasSwapId: numberOrHex.nullish(),
   }),
   z.object({ __kind: z.literal('NoAction') }),
 ]);

--- a/packages/processor/generated/141/common.ts
+++ b/packages/processor/generated/141/common.ts
@@ -275,11 +275,9 @@ export const cfPrimitivesBeneficiary = z.object({ account: accountId, bps: z.num
 export const cfChainsSwapOrigin = z.union([
   z.object({
     __kind: z.literal('DepositChannel'),
-    value: z.object({
-      depositAddress: cfChainsAddressEncodedAddress,
-      channelId: numberOrHex,
-      depositBlockHeight: numberOrHex,
-    }),
+    depositAddress: cfChainsAddressEncodedAddress,
+    channelId: numberOrHex,
+    depositBlockHeight: numberOrHex,
   }),
   z.object({ __kind: z.literal('Vault'), txHash: hexString }),
 ]);
@@ -290,10 +288,7 @@ export const cfChainsBtcScriptPubkey = z.union([
   z.object({ __kind: z.literal('P2WPKH'), value: hexString }),
   z.object({ __kind: z.literal('P2WSH'), value: hexString }),
   z.object({ __kind: z.literal('Taproot'), value: hexString }),
-  z.object({
-    __kind: z.literal('OtherSegwit'),
-    value: z.object({ version: z.number(), program: hexString }),
-  }),
+  z.object({ __kind: z.literal('OtherSegwit'), version: z.number(), program: hexString }),
 ]);
 
 export const cfChainsAddressForeignChainAddress = z.union([
@@ -331,7 +326,8 @@ export const palletCfIngressEgressDepositAction = z.union([
   z.object({ __kind: z.literal('LiquidityProvision'), lpAccount: accountId }),
   z.object({
     __kind: z.literal('CcmTransfer'),
-    value: z.object({ principalSwapId: numberOrHex.nullish(), gasSwapId: numberOrHex.nullish() }),
+    principalSwapId: numberOrHex.nullish(),
+    gasSwapId: numberOrHex.nullish(),
   }),
   z.object({ __kind: z.literal('NoAction') }),
   z.object({ __kind: z.literal('BoostersCredited'), prewitnessedDepositId: numberOrHex }),

--- a/packages/processor/src/codegen/CodeGenerator.ts
+++ b/packages/processor/src/codegen/CodeGenerator.ts
@@ -206,7 +206,8 @@ export default class CodeGenerator {
             return `z.object({ __kind: z.literal('${v.name}') })`;
           }
 
-          if (v.value.type === 'struct' && Object.keys(v.value.fields).length === 1) {
+          // if the struct has no name, it is not actually a struct but an enum variant w/ named fields
+          if (v.value.type === 'struct' && v.value.name === undefined) {
             const value = this.generateStruct({
               ...v.value,
               additionalFields: {


### PR DESCRIPTION
Disambiguates between:

```rs
struct SomeStruct {
  a: u32
}

enum Foo {
  Bar(SomeStruct),
  BarWithFields {
    a: u32
  }
}
```

i.e:

```ts
const someStruct = z.object({ a: z.number() });

const foo = z.union([
  z.object({ __kind: z.literal('Bar'), value: someStruct }),
  //                                   ^^^^^ nested value
  z.object({ __kind: z.literal('BarWithFields'), a: z.number() }),
  //                                             ^^^^^^^^^^^^^ flat
]);
```