### PR TITLE
fix: Increase max_old_space_size to prevent heap out of memory errors when publishing

### DIFF
--- a/.github/workflows/_npm_publish.yml
+++ b/.github/workflows/_npm_publish.yml
@@ -69,9 +69,12 @@ jobs:
           done
 
       - name: Build 🏗️
+        env:
+          NODE_OPTIONS: '--max_old_space_size=8192'
         run: ${{ inputs.build_cmd }}
 
       - name: Publish npm package 📦
         env:
+          NODE_OPTIONS: '--max_old_space_size=8192'
           NODE_AUTH_TOKEN: ${{ secrets.node_auth_token }}
         run: ${{ inputs.publish_cmd }}


### PR DESCRIPTION
https://github.com/chainflip-io/chainflip-product-toolkit/actions/runs/12655905398/job/35267388511