### PR TITLE
fix: add exclude_fees to cf_swap_rate_v3 method[WEB-1794]

### DIFF
--- a/.github/workflows/matrix.json
+++ b/.github/workflows/matrix.json
@@ -1,12 +1,4 @@
 {
-  "package": [
-    "bitcoin",
-    "chainspec",
-    "extrinsics",
-    "processor",
-    "rpc",
-    "solana",
-    "utils"
-  ],
+  "package": ["bitcoin", "chainspec", "extrinsics", "processor", "rpc", "solana", "utils"],
   "include": []
 }

--- a/.github/workflows/matrix.json
+++ b/.github/workflows/matrix.json
@@ -1,4 +1,12 @@
 {
-  "package": ["bitcoin", "chainspec", "extrinsics", "processor", "rpc", "solana", "utils"],
+  "package": [
+    "bitcoin", 
+    "chainspec", 
+    "extrinsics", 
+    "processor", 
+    "rpc", 
+    "solana", 
+    "utils"
+  ],
   "include": []
 }

--- a/.github/workflows/matrix.json
+++ b/.github/workflows/matrix.json
@@ -1,11 +1,11 @@
 {
   "package": [
-    "bitcoin", 
-    "chainspec", 
-    "extrinsics", 
-    "processor", 
-    "rpc", 
-    "solana", 
+    "bitcoin",
+    "chainspec",
+    "extrinsics",
+    "processor",
+    "rpc",
+    "solana",
     "utils"
   ],
   "include": []

--- a/packages/rpc/src/__tests__/HttpClient.test.ts
+++ b/packages/rpc/src/__tests__/HttpClient.test.ts
@@ -931,6 +931,63 @@ describe(HttpClient, () => {
       `);
     });
 
+    it('does the swap rate v3 with ccm_data and exclude_fees fields', async () => {
+      expect(
+        await client.sendRequest(
+          'cf_swap_rate_v3',
+          { asset: 'USDT', chain: 'Ethereum' },
+          { asset: 'USDC', chain: 'Ethereum' },
+          '0x10000',
+          10,
+          {
+            number_of_chunks: 10,
+            chunk_interval: 2,
+          },
+          {
+            gas_budget: '0x',
+            message_length: 0,
+          },
+          ['Ingress'],
+          [
+            {
+              LimitOrder: {
+                base_asset: { asset: 'USDT', chain: 'Ethereum' },
+                quote_asset: { asset: 'USDC', chain: 'Ethereum' },
+                side: 'buy',
+                tick: 0,
+                sell_amount: '0x10000',
+              },
+            },
+          ],
+        ),
+      ).toMatchInlineSnapshot(`
+        {
+          "broker_commission": {
+            "amount": 0n,
+            "asset": "USDC",
+            "chain": "Ethereum",
+          },
+          "egress_fee": {
+            "amount": 0n,
+            "asset": "USDC",
+            "chain": "Ethereum",
+          },
+          "ingress_fee": {
+            "amount": 0n,
+            "asset": "USDT",
+            "chain": "Ethereum",
+          },
+          "intermediary": null,
+          "network_fee": {
+            "amount": 66n,
+            "asset": "USDC",
+            "chain": "Ethereum",
+          },
+          "output": 65468n,
+        }
+      `);
+    });
+
     it('gets validator account info', async () => {
       expect(await client.sendRequest('cf_account_info', VALIDATOR_ACCOUNT_ID)).toMatchSnapshot();
     });

--- a/packages/rpc/src/__tests__/HttpClient.test.ts
+++ b/packages/rpc/src/__tests__/HttpClient.test.ts
@@ -891,11 +891,6 @@ describe(HttpClient, () => {
             number_of_chunks: 10,
             chunk_interval: 2,
           },
-          {
-            gas_budget: '0x',
-            message_length: 0,
-          },
-          [],
           [
             {
               LimitOrder: {

--- a/packages/rpc/src/__tests__/HttpClient.test.ts
+++ b/packages/rpc/src/__tests__/HttpClient.test.ts
@@ -891,6 +891,7 @@ describe(HttpClient, () => {
             number_of_chunks: 10,
             chunk_interval: 2,
           },
+          [],
           [
             {
               LimitOrder: {

--- a/packages/rpc/src/__tests__/HttpClient.test.ts
+++ b/packages/rpc/src/__tests__/HttpClient.test.ts
@@ -891,6 +891,10 @@ describe(HttpClient, () => {
             number_of_chunks: 10,
             chunk_interval: 2,
           },
+          {
+            gas_budget: '0x',
+            message_length: 0,
+          },
           [],
           [
             {

--- a/packages/rpc/src/common.ts
+++ b/packages/rpc/src/common.ts
@@ -98,22 +98,34 @@ export type RpcRequest = WithHash<{
     amount: `0x${string}`,
     additionalOrders?: Nullish<AdditionalOrder[]>,
   ];
-  cf_swap_rate_v3: [
-    fromAsset: UncheckedAssetAndChain,
-    toAsset: UncheckedAssetAndChain,
-    amount: `0x${string}`,
-    brokerComission?: Nullish<number>,
-    dcaParams?: Nullish<{
-      number_of_chunks: number;
-      chunk_interval: number;
-    }>,
-    ccm_data?: Nullish<{
-      gas_budget: HexString;
-      message_length: number;
-    }>,
-    exclude_fees?: Nullish<SwapFeeType[]>,
-    additionalOrders?: Nullish<AdditionalOrder[]>,
-  ];
+  cf_swap_rate_v3:
+    | [
+        fromAsset: UncheckedAssetAndChain,
+        toAsset: UncheckedAssetAndChain,
+        amount: `0x${string}`,
+        brokerComission?: Nullish<number>,
+        dcaParams?: Nullish<{
+          number_of_chunks: number;
+          chunk_interval: number;
+        }>,
+        additionalOrders?: Nullish<AdditionalOrder[]>,
+      ]
+    | [
+        fromAsset: UncheckedAssetAndChain,
+        toAsset: UncheckedAssetAndChain,
+        amount: `0x${string}`,
+        brokerComission: number,
+        dcaParams?: Nullish<{
+          number_of_chunks: number;
+          chunk_interval: number;
+        }>,
+        ccm_data?: Nullish<{
+          gas_budget: HexString;
+          message_length: number;
+        }>,
+        exclude_fees?: Nullish<SwapFeeType[]>,
+        additionalOrders?: Nullish<AdditionalOrder[]>,
+      ];
   cf_boost_pools_depth: [];
   cf_boost_pool_details: [asset?: UncheckedAssetAndChain | null];
   cf_boost_pool_pending_fees: [asset?: UncheckedAssetAndChain | null];

--- a/packages/rpc/src/common.ts
+++ b/packages/rpc/src/common.ts
@@ -107,6 +107,10 @@ export type RpcRequest = WithHash<{
       number_of_chunks: number;
       chunk_interval: number;
     }>,
+    ccm_data?: Nullish<{
+      gas_budget: HexString;
+      message_length: number;
+    }>,
     exclude_fees?: Nullish<SwapFeeType[]>,
     additionalOrders?: Nullish<AdditionalOrder[]>,
   ];

--- a/packages/rpc/src/common.ts
+++ b/packages/rpc/src/common.ts
@@ -38,6 +38,8 @@ type AssetSymbol = AssetAndChain['asset'];
 
 type UncheckedAssetAndChain = { asset: AssetSymbol; chain: Chain };
 
+type SwapFeeType = 'Network' | 'Ingress' | 'Egress';
+
 type AdditionalOrder = {
   LimitOrder: {
     base_asset: UncheckedAssetAndChain;
@@ -105,6 +107,7 @@ export type RpcRequest = WithHash<{
       number_of_chunks: number;
       chunk_interval: number;
     }>,
+    exclude_fees?: Nullish<SwapFeeType[]>,
     additionalOrders?: Nullish<AdditionalOrder[]>,
   ];
   cf_boost_pools_depth: [];

--- a/packages/rpc/src/common.ts
+++ b/packages/rpc/src/common.ts
@@ -119,11 +119,11 @@ export type RpcRequest = WithHash<{
           number_of_chunks: number;
           chunk_interval: number;
         }>,
-        ccm_data?: Nullish<{
+        ccmData?: Nullish<{
           gas_budget: HexString;
           message_length: number;
         }>,
-        exclude_fees?: Nullish<SwapFeeType[]>,
+        excludeFees?: Nullish<SwapFeeType[]>,
         additionalOrders?: Nullish<AdditionalOrder[]>,
       ];
   cf_boost_pools_depth: [];


### PR DESCRIPTION
As a part of [do not include ingress fee when quoting vault swaps](https://linear.app/chainflip/issue/WEB-1794/do-not-include-ingress-fee-when-quoting-vault-swaps), need to include the `exclude_fees` fields that which has already been added to the backend, needs to be included.