### PR TITLE
refactor(rpc): improve stack trace

### DIFF
--- a/packages/rpc/src/Client.ts
+++ b/packages/rpc/src/Client.ts
@@ -106,7 +106,11 @@ export default abstract class Client {
         void this.handleBatch();
       }, 0);
     }
-    return deferred.promise;
+
+    return deferred.promise.catch((error) => {
+      if (error instanceof Error) Error.captureStackTrace(error);
+      throw error;
+    });
   }
 
   methods(): RpcMethod[] {


### PR DESCRIPTION
if we consider this code:
```ts
// main.ts
import HttpClient from './HttpClient';

const getAccounts = async () => {
  const client = new HttpClient('http://localhost:3000/rpc');

  try {
    await client.sendRequest('cf_accounts');
  } catch (error) {
    console.error(error.stack);
  }
};

await getAccounts();
```

before this change, it is difficult to find the source of the error because the error is created within a timeout or something so it's not attached to the stack of the actual caller of `sendRequest`
```
Error: Network error
    at HttpClient.send (/chainflip-product-toolkit/packages/rpc/src/HttpClient.ts:19:32)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at HttpClient.handleBatch (/chainflip-product-toolkit/packages/rpc/src/Client.ts:86:5)
```

so instead we manually capture the stack in case of error:
```
Error: Network error
    at <anonymous> (/chainflip-product-toolkit/packages/rpc/src/Client.ts:111:41)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at getAccounts (/chainflip-product-toolkit/packages/rpc/src/main.ts:7:5)
    at <anonymous> (/chainflip-product-toolkit/packages/rpc/src/main.ts:13:1)
```    