### PR TITLE
chore(solana): handle balance diffing for multiple account creations

### DIFF
--- a/packages/solana/src/__test__/deposit.test.ts
+++ b/packages/solana/src/__test__/deposit.test.ts
@@ -19,6 +19,7 @@ import combineTxs from './fixtures/combineTxs.json';
 import devnet from './fixtures/devnet.json';
 import doubleTransfer from './fixtures/doubleTransfer.json';
 import maxBlockError from './fixtures/maxBlockError.json';
+import multipleTokenAccounts from './fixtures/multipleTokenAccounts.json';
 import notVaultSwap from './fixtures/notVaultSwap.json';
 import paginate1 from './fixtures/paginate1.json';
 import paginate2 from './fixtures/paginate2.json';
@@ -311,6 +312,25 @@ describe(findTransactionSignatures, () => {
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `[TransactionMatchingError: transfers are too new]`,
     );
+  });
+
+  it('sums all token accounts when a tx creates multiple accounts for the same owner and mint', async () => {
+    // Regression test for tx 25nS8WuLqkQ4qkHpJpyGrRpiCxEYzKPN7vKeNzbsGE7scNgXe74ip6WNW2HxxKT5ViE6p7DsweKB9gbc4M3jygZs
+    // (slot 415551828): a single tx created two USDT accounts for deposit address
+    // 7f3msGebEdNAeWGhnFDobgXJYcWwvJDmCuv6bzmWunCf — a non-canonical account (index 1, 0 USDT)
+    // and the canonical ATA (index 3, 0.001 USDT). The old .find() matched index 1 first, giving
+    // diff=0 which was filtered out, causing the deposit to be missed.
+    mockFetch(multipleTokenAccounts);
+    const result = await findTransactionSignatures(
+      'https://solana.rpc',
+      '7f3msGebEdNAeWGhnFDobgXJYcWwvJDmCuv6bzmWunCf',
+      'SolUsdt',
+      [{ amount: 1000n, maxSlot: Infinity }],
+      'mainnet',
+    );
+    expect(result).toStrictEqual([
+      ['25nS8WuLqkQ4qkHpJpyGrRpiCxEYzKPN7vKeNzbsGE7scNgXe74ip6WNW2HxxKT5ViE6p7DsweKB9gbc4M3jygZs'],
+    ]);
   });
 
   it('works with SolUsdc transfers from RPC', async () => {

--- a/packages/solana/src/__test__/fixtures/multipleTokenAccounts.json
+++ b/packages/solana/src/__test__/fixtures/multipleTokenAccounts.json
@@ -1,0 +1,256 @@
+{
+  "signatures": {
+    "jsonrpc": "2.0",
+    "result": [
+      {
+        "blockTime": 1777114915,
+        "confirmationStatus": "finalized",
+        "err": null,
+        "memo": null,
+        "signature": "25nS8WuLqkQ4qkHpJpyGrRpiCxEYzKPN7vKeNzbsGE7scNgXe74ip6WNW2HxxKT5ViE6p7DsweKB9gbc4M3jygZs",
+        "slot": 415551828
+      }
+    ],
+    "id": "1"
+  },
+  "transactions": [
+    {
+      "jsonrpc": "2.0",
+      "result": {
+        "blockTime": 1777114915,
+        "meta": {
+          "computeUnitsConsumed": 55239,
+          "costUnits": 57271,
+          "err": null,
+          "fee": 5000,
+          "innerInstructions": [
+            {
+              "index": 1,
+              "instructions": [
+                {
+                  "accounts": [9],
+                  "data": "84eT",
+                  "programIdIndex": 6,
+                  "stackHeight": null
+                },
+                {
+                  "accounts": [0, 3],
+                  "data": "11119os1e9qSs2u7TsThXqkBSRVFxhmYaFKFZ1waB2X7armDmvK3p5GmLdUxYdg3h7QSrL",
+                  "programIdIndex": 4,
+                  "stackHeight": null
+                },
+                {
+                  "accounts": [3],
+                  "data": "P",
+                  "programIdIndex": 6,
+                  "stackHeight": null
+                },
+                {
+                  "accounts": [3, 9],
+                  "data": "6TnkSoUBPXUdzuzNDsQR95exh3W6mL3VTuq5x6aTLCvdd",
+                  "programIdIndex": 6,
+                  "stackHeight": null
+                }
+              ]
+            }
+          ],
+          "loadedAddresses": {
+            "readonly": [],
+            "writable": []
+          },
+          "logMessages": [
+            "Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL invoke [1]",
+            "Program log: CreateIdempotent",
+            "Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL consumed 4338 of 1400000 compute units",
+            "Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL success",
+            "Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL invoke [1]",
+            "Program log: CreateIdempotent",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
+            "Program log: Instruction: GetAccountDataSize",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 1622 of 1385733 compute units",
+            "Program return: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA pQAAAAAAAAA=",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+            "Program 11111111111111111111111111111111 invoke [2]",
+            "Program 11111111111111111111111111111111 success",
+            "Program log: Initialize the associated token account",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
+            "Program log: Instruction: InitializeImmutableOwner",
+            "Program log: Please upgrade to SPL Token 2022 for immutable owner support",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 1405 of 1379201 compute units",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
+            "Program log: Instruction: InitializeAccount3",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4241 of 1375370 compute units",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+            "Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL consumed 24837 of 1395662 compute units",
+            "Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL success",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [1]",
+            "Program log: Instruction: TransferChecked",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 6199 of 1370825 compute units",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+            "Program 11111111111111111111111111111111 invoke [1]",
+            "Program 11111111111111111111111111111111 success",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [1]",
+            "Program log: Instruction: InitializeAccount",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4526 of 1364476 compute units",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [1]",
+            "Program log: Instruction: TransferChecked",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 6199 of 1359950 compute units",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [1]",
+            "Program log: Instruction: TransferChecked",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 6199 of 1353751 compute units",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [1]",
+            "Program log: Instruction: SetAuthority",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 2791 of 1347552 compute units",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success"
+          ],
+          "postBalances": [
+            321809802, 2039280, 2039280, 2039280, 1, 1009200, 5598856254, 0, 3387961056,
+            187265068961
+          ],
+          "postTokenBalances": [
+            {
+              "accountIndex": 1,
+              "mint": "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+              "owner": "7f3msGebEdNAeWGhnFDobgXJYcWwvJDmCuv6bzmWunCf",
+              "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "uiTokenAmount": {
+                "amount": "0",
+                "decimals": 6,
+                "uiAmount": null,
+                "uiAmountString": "0"
+              }
+            },
+            {
+              "accountIndex": 2,
+              "mint": "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+              "owner": "Drv6cXN7nRhnutDf9Qyjmwq65GDhCUxmUL9ktNFkSYUY",
+              "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "uiTokenAmount": {
+                "amount": "27398000",
+                "decimals": 6,
+                "uiAmount": 27.398,
+                "uiAmountString": "27.398"
+              }
+            },
+            {
+              "accountIndex": 3,
+              "mint": "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+              "owner": "7f3msGebEdNAeWGhnFDobgXJYcWwvJDmCuv6bzmWunCf",
+              "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "uiTokenAmount": {
+                "amount": "1000",
+                "decimals": 6,
+                "uiAmount": 0.001,
+                "uiAmountString": "0.001"
+              }
+            }
+          ],
+          "preBalances": [
+            325893362, 0, 2039280, 0, 1, 1009200, 5598856254, 0, 3387961056, 187265068961
+          ],
+          "preTokenBalances": [
+            {
+              "accountIndex": 2,
+              "mint": "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+              "owner": "Drv6cXN7nRhnutDf9Qyjmwq65GDhCUxmUL9ktNFkSYUY",
+              "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "uiTokenAmount": {
+                "amount": "27399000",
+                "decimals": 6,
+                "uiAmount": 27.399,
+                "uiAmountString": "27.399"
+              }
+            }
+          ],
+          "rewards": [],
+          "status": {
+            "Ok": null
+          }
+        },
+        "slot": 415551828,
+        "transaction": {
+          "message": {
+            "accountKeys": [
+              "Drv6cXN7nRhnutDf9Qyjmwq65GDhCUxmUL9ktNFkSYUY",
+              "13cSkEkvs16m4JNNmDFc26WjkpvTGaXnhPPR4PqmqbeK",
+              "3E1awiLQaYKoUxgCo2UEe6ui44tZ1m7TNtoLfqguBRUD",
+              "5QFKi5mQvq7opPfjE1mtKDLXQ3mLJ2KSukYBfhoi1TJH",
+              "11111111111111111111111111111111",
+              "SysvarRent111111111111111111111111111111111",
+              "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "7f3msGebEdNAeWGhnFDobgXJYcWwvJDmCuv6bzmWunCf",
+              "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+              "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB"
+            ],
+            "header": {
+              "numReadonlySignedAccounts": 0,
+              "numReadonlyUnsignedAccounts": 6,
+              "numRequiredSignatures": 1
+            },
+            "instructions": [
+              {
+                "accounts": [0, 2, 0, 9, 4, 6],
+                "data": "2",
+                "programIdIndex": 8,
+                "stackHeight": null
+              },
+              {
+                "accounts": [0, 3, 7, 9, 4, 6],
+                "data": "2",
+                "programIdIndex": 8,
+                "stackHeight": null
+              },
+              {
+                "accounts": [2, 9, 3, 0],
+                "data": "j4EYRhtmbmRQq",
+                "programIdIndex": 6,
+                "stackHeight": null
+              },
+              {
+                "accounts": [0, 1, 0],
+                "data": "3ipZWzzFPdbRTKUmHh2Qar2Rpbsx1bSZNrz9tGAfBcmgbX1YGWeytKre7jQwFr5imsGEWqBqxFYs9fkya95CxqRfhy5jN8MNi6JajinE9CgeHywtDTTBfVpcF5Kiypgtq2PcVpTzEZkz2cCs4ayjLhASJuT4tKuF5rcBTDdMJ",
+                "programIdIndex": 4,
+                "stackHeight": null
+              },
+              {
+                "accounts": [1, 9, 0, 5],
+                "data": "2",
+                "programIdIndex": 6,
+                "stackHeight": null
+              },
+              {
+                "accounts": [2, 9, 1, 0],
+                "data": "g75WwQvhbPQ37",
+                "programIdIndex": 6,
+                "stackHeight": null
+              },
+              {
+                "accounts": [1, 9, 2, 0],
+                "data": "g75WwQvhbPQ37",
+                "programIdIndex": 6,
+                "stackHeight": null
+              },
+              {
+                "accounts": [1, 0],
+                "data": "bmb4PnKogXhTC5Ah1G8aftRiprd54QsDhm4197ivgQBXMuZ",
+                "programIdIndex": 6,
+                "stackHeight": null
+              }
+            ],
+            "recentBlockhash": "5EJKh7TrTsm3PAs9v79MGa4935qpCHqjhVUZN1m8DD1M",
+            "addressTableLookups": []
+          },
+          "signatures": [
+            "25nS8WuLqkQ4qkHpJpyGrRpiCxEYzKPN7vKeNzbsGE7scNgXe74ip6WNW2HxxKT5ViE6p7DsweKB9gbc4M3jygZs"
+          ]
+        },
+        "version": 0
+      },
+      "id": "1"
+    }
+  ]
+}

--- a/packages/solana/src/deposit.ts
+++ b/packages/solana/src/deposit.ts
@@ -70,15 +70,14 @@ const getTokenDiff = (
 
   const owner = publicKey.toBase58();
 
-  const preTokenAmount = tx.meta.preTokenBalances.find(
-    (b) => b.mint === tokenMintAddress && b.owner === owner,
-  );
-  const postTokenAmount = tx.meta.postTokenBalances.find(
-    (b) => b.mint === tokenMintAddress && b.owner === owner,
-  );
-
-  const preBalance = BigInt(preTokenAmount?.uiTokenAmount.amount ?? 0);
-  const postBalance = BigInt(postTokenAmount?.uiTokenAmount.amount ?? 0);
+  const preBalance = tx.meta.preTokenBalances
+    .filter((b) => b.mint === tokenMintAddress && b.owner === owner)
+    // Handle multiple token account creations in the same transaction by summing up all balances of accounts owned by the same owner and mint
+    .reduce((sum, b) => sum + BigInt(b.uiTokenAmount.amount), 0n);
+  const postBalance = tx.meta.postTokenBalances
+    .filter((b) => b.mint === tokenMintAddress && b.owner === owner)
+    // Handle multiple token account creations in the same transaction by summing up all balances of accounts owned by the same owner and mint
+    .reduce((sum, b) => sum + BigInt(b.uiTokenAmount.amount), 0n);
   return postBalance - preBalance;
 };
 


### PR DESCRIPTION
Root Cause

  The transaction
  25nS8WuLqkQ4qkHpJpyGrRpiCxEYzKPN7vKeNzbsGE7scNgXe74ip6WNW2HxxKT5ViE6p7DsweKB9gbc4M3jygZs
  (slot 415551828) created TWO USDT token accounts for the deposit address
  7f3msGebEdNAeWGhnFDobgXJYcWwvJDmCuv6bzmWunCf in the same transaction:

  ```
  ┌──────────────────┬───────────────┬─────────────────────────────┬────────────┐
  │     Address      │ Account index │            Type             │  Balance   │
  ├──────────────────┼───────────────┼─────────────────────────────┼────────────┤
  │ 13cSkEkvs16m4... │ 1             │ Non-canonical token account │ 0 USDT     │
  ├──────────────────┼───────────────┼─────────────────────────────┼────────────┤
  │ 5QFKi5mQvq7op... │ 3             │ Canonical ATA               │ 0.001 USDT │
  └──────────────────┴───────────────┴─────────────────────────────┴────────────┘
```
  The bug is in getTokenDiff in @chainflip/solana@2.2.2 (deposit.mjs:28):
```
  const getTokenDiff = (tx, publicKey, tokenMintAddress) => {
      const owner = publicKey.toBase58();
      const preTokenAmount = tx.meta.preTokenBalances.find((b) => b.mint ===
  tokenMintAddress && b.owner === owner);
      const postTokenAmount = tx.meta.postTokenBalances.find((b) => b.mint ===
  tokenMintAddress && b.owner === owner);
```
  .find() returns the first matching token account. Since both accounts share the same
  owner (the deposit address) and mint (USDT), it finds the non-canonical account (account
  index 1) before the canonical ATA (index 3). That account has 0 balance, so diff = 0.

  Because diff <= 0n, the transfer is excluded from results. The loop then tries to
  paginate to even older signatures, but there are none — so getSignaturesForAddress
  returns empty on the second iteration, and assert(sigs.length > 0, "failed to find
  signatures") fires.

  The Fix

  In @chainflip/solana, getTokenDiff should sum all token accounts matching (owner, mint)
  instead of taking just the first:
```
  // Before (buggy)
  const preTokenAmount = tx.meta.preTokenBalances.find((b) => b.mint === tokenMintAddress
  && b.owner === owner);
  const postTokenAmount = tx.meta.postTokenBalances.find((b) => b.mint === tokenMintAddress
   && b.owner === owner);
  const preBalance = BigInt(preTokenAmount?.uiTokenAmount.amount ?? 0);
  return BigInt(postTokenAmount?.uiTokenAmount.amount ?? 0) - preBalance;
```
```
  // After (fixed)
  const preBalance = tx.meta.preTokenBalances
      .filter((b) => b.mint === tokenMintAddress && b.owner === owner)
      .reduce((sum, b) => sum + BigInt(b.uiTokenAmount.amount), 0n);
  const postBalance = tx.meta.postTokenBalances
      .filter((b) => b.mint === tokenMintAddress && b.owner === owner)
      .reduce((sum, b) => sum + BigInt(b.uiTokenAmount.amount), 0n);
  return postBalance - preBalance;
```