### PR TITLE
fix(rpc): harden ccm_deposit_metadata in ingress-egress vault deposit

### DIFF
--- a/packages/rpc/src/parsers.ts
+++ b/packages/rpc/src/parsers.ts
@@ -902,6 +902,29 @@ const ingressEgressBroadcast = z.object({
   tx_ref: txRef,
 });
 
+const foreignChain = z.enum(['Ethereum', 'Polkadot', 'Bitcoin', 'Arbitrum', 'Solana', 'Assethub']); // TODO: add Tron for 2.2?
+
+const foreignChainAddress = z.union([
+  z.object({ Eth: z.string() }),
+  z.object({ Dot: z.string() }),
+  z.object({ Btc: z.unknown() }), // do we care about inner structure here or just need to know the source chain
+  z.object({ Arb: z.string() }),
+  z.object({ Sol: z.string() }),
+  z.object({ Hub: z.string() }),
+]);
+
+const ccmChannelMetadata = z.object({
+  message: z.string(),
+  gas_budget: u128,
+  ccm_additional_data: z.string(),
+});
+
+const ccmDepositMetadata = z.object({
+  channel_metadata: ccmChannelMetadata,
+  source_chain: foreignChain,
+  source_address: foreignChainAddress.nullable(),
+});
+
 const ingressEgressVaultDeposit = z.object({
   tx_id: z.string(),
   deposit_chain_block_height: z.number().nullable().optional(),
@@ -909,7 +932,7 @@ const ingressEgressVaultDeposit = z.object({
   output_asset: z.object({ chain: z.string(), asset: z.string() }),
   amount: u128,
   destination_address: z.string(),
-  ccm_deposit_metadata: z.unknown().nullable().optional(),
+  ccm_deposit_metadata: ccmDepositMetadata.nullable(),
   deposit_details: z.unknown().nullable().optional(),
   broker_fee: z
     .object({
@@ -937,7 +960,7 @@ const ingressEgressVaultDeposit = z.object({
       retry_duration: z.number(),
       refund_address: z.string(),
       min_price: u128,
-      refund_ccm_metadata: z.unknown().nullable().optional(),
+      refund_ccm_metadata: ccmChannelMetadata.nullable(),
       max_oracle_price_slippage: z.number().nullable().optional(),
     })
     .nullable()


### PR DESCRIPTION
Tried to do an audit of `ingressEgressDeposit`, `ingressEgressBroadcast` and `ingressEgressVaultDeposit` RPC-package parsers in `swap-server`, and discovered that `ccm_deposit_metadata ` shape might be too loose ( it used to be `unknown`)

```
ccm_deposit_metadata: strict shape IS required
The swap server reads channelMetadata.gasBudget and channelMetadata.message. So the redis parser MUST stay strict on { channel_metadata: { message, gas_budget, ... } }. 

Recommendation: tighten the tracker's parser to match this shape too (instead of z.unknown()), so bad data fails at write-time rather than crashing the swap server on read.
``` 

meanwhile REDIS parser requires a specific shape 

so i think it's better to harden this as well to avoid swap server throwing errors. 