### PR TITLE
chore: add dependabot cooldown

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,6 +8,8 @@ updates:
     commit-message:
       prefix: 'chore'
       include: 'scope'
+    cooldown:
+      default-days: 14
     groups:
       types:
         patterns:


### PR DESCRIPTION
stops dependabot from opening PRs for fresh pacakges