### PR TITLE
chore(utils): move over number/lending utilities

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainflip/utils",
-  "version": "2.2.0-alpha.3",
+  "version": "2.2.0-alpha.4",
   "type": "module",
   "scripts": {
     "eslint:check": "pnpm eslint --max-warnings 0 './**/*.ts'",

--- a/packages/utils/src/__tests__/lending.test.ts
+++ b/packages/utils/src/__tests__/lending.test.ts
@@ -4,6 +4,7 @@ import {
   calculateLoanToValueBps,
   calculateTotalEffectiveBorrowableAmount,
   ppmToBps,
+  ppmToDecimal,
 } from '../lending';
 
 describe(ppmToBps, () => {
@@ -26,6 +27,28 @@ describe(ppmToBps, () => {
 
   it('returns 0 for 0 ppm', () => {
     expect(ppmToBps(0)).toBe(0);
+  });
+});
+
+describe(ppmToDecimal, () => {
+  it('converts 100% utilisation (1_000_000 ppm) to 1', () => {
+    expect(ppmToDecimal(1_000_000)).toBe(1);
+  });
+
+  it('converts 50% utilisation (500_000 ppm) to 0.5', () => {
+    expect(ppmToDecimal(500_000)).toBe(0.5);
+  });
+
+  it('converts 1% utilisation (10_000 ppm) to 0.01', () => {
+    expect(ppmToDecimal(10_000)).toBe(0.01);
+  });
+
+  it('converts 1 ppm to 0.000001', () => {
+    expect(ppmToDecimal(1)).toBe(0.000001);
+  });
+
+  it('returns 0 for 0 ppm', () => {
+    expect(ppmToDecimal(0)).toBe(0);
   });
 });
 

--- a/packages/utils/src/__tests__/lending.test.ts
+++ b/packages/utils/src/__tests__/lending.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { calculateTotalEffectiveBorrowableAmount, ppmToBps } from '../lending';
+
+describe(ppmToBps, () => {
+  it('converts 100% utilisation (1_000_000 ppm) to 10_000 bps', () => {
+    expect(ppmToBps(1_000_000)).toBe(10_000);
+  });
+
+  it('converts 50% utilisation (500_000 ppm) to 5_000 bps', () => {
+    expect(ppmToBps(500_000)).toBe(5_000);
+  });
+
+  it('converts 1% utilisation (10_000 ppm) to 100 bps', () => {
+    expect(ppmToBps(10_000)).toBe(100);
+  });
+
+  it('truncates fractional bps', () => {
+    expect(ppmToBps(150)).toBe(1);
+    expect(ppmToBps(99)).toBe(0);
+  });
+
+  it('returns 0 for 0 ppm', () => {
+    expect(ppmToBps(0)).toBe(0);
+  });
+});
+
+describe(calculateTotalEffectiveBorrowableAmount, () => {
+  it('returns available amount when no utilisation cap is set', () => {
+    expect(
+      calculateTotalEffectiveBorrowableAmount({
+        totalAmount: 1_000n,
+        totalAvailableAmount: 600n,
+      }),
+    ).toBe(600n);
+  });
+
+  it('returns available amount when utilisation cap is null', () => {
+    expect(
+      calculateTotalEffectiveBorrowableAmount({
+        totalAmount: 2_000n,
+        totalAvailableAmount: 800n,
+        utilisationCap: null,
+      }),
+    ).toBe(800n);
+  });
+
+  it('caps borrowable amount based on utilisation cap', () => {
+    // 50% cap: effective = 1000 * 0.5 = 500, borrowed = 400, borrowable = 100
+    expect(
+      calculateTotalEffectiveBorrowableAmount({
+        totalAmount: 1_000n,
+        totalAvailableAmount: 600n,
+        utilisationCap: 500_000,
+      }),
+    ).toBe(100n);
+  });
+
+  it('returns 0n when already at or over the utilisation cap', () => {
+    // 50% cap: effective = 500, borrowed = 600, would be negative → 0n
+    expect(
+      calculateTotalEffectiveBorrowableAmount({
+        totalAmount: 1_000n,
+        totalAvailableAmount: 400n,
+        utilisationCap: 500_000,
+      }),
+    ).toBe(0n);
+  });
+
+  it('returns 0n when pool is fully borrowed', () => {
+    expect(
+      calculateTotalEffectiveBorrowableAmount({
+        totalAmount: 1_000n,
+        totalAvailableAmount: 0n,
+        utilisationCap: 1_000_000,
+      }),
+    ).toBe(0n);
+  });
+
+  it('returns total amount when pool is empty and no cap', () => {
+    expect(
+      calculateTotalEffectiveBorrowableAmount({
+        totalAmount: 5_000n,
+        totalAvailableAmount: 5_000n,
+      }),
+    ).toBe(5_000n);
+  });
+});

--- a/packages/utils/src/__tests__/lending.test.ts
+++ b/packages/utils/src/__tests__/lending.test.ts
@@ -67,7 +67,7 @@ describe(calculateTotalEffectiveBorrowableAmount, () => {
       calculateTotalEffectiveBorrowableAmount({
         totalAmount: 2_000n,
         totalAvailableAmount: 800n,
-        utilisationCap: null,
+        utilisationCapBps: null,
       }),
     ).toBe(800n);
   });
@@ -78,7 +78,7 @@ describe(calculateTotalEffectiveBorrowableAmount, () => {
       calculateTotalEffectiveBorrowableAmount({
         totalAmount: 1_000n,
         totalAvailableAmount: 600n,
-        utilisationCap: 500_000,
+        utilisationCapBps: 5_000,
       }),
     ).toBe(100n);
   });
@@ -89,7 +89,7 @@ describe(calculateTotalEffectiveBorrowableAmount, () => {
       calculateTotalEffectiveBorrowableAmount({
         totalAmount: 1_000n,
         totalAvailableAmount: 400n,
-        utilisationCap: 500_000,
+        utilisationCapBps: 5_000,
       }),
     ).toBe(0n);
   });
@@ -99,7 +99,7 @@ describe(calculateTotalEffectiveBorrowableAmount, () => {
       calculateTotalEffectiveBorrowableAmount({
         totalAmount: 1_000n,
         totalAvailableAmount: 0n,
-        utilisationCap: 1_000_000,
+        utilisationCapBps: 10_000,
       }),
     ).toBe(0n);
   });

--- a/packages/utils/src/__tests__/lending.test.ts
+++ b/packages/utils/src/__tests__/lending.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { calculateTotalEffectiveBorrowableAmount, ppmToBps } from '../lending';
+import {
+  calculateBorrowPowerUsedBps,
+  calculateLoanToValueBps,
+  calculateTotalEffectiveBorrowableAmount,
+  ppmToBps,
+} from '../lending';
 
 describe(ppmToBps, () => {
   it('converts 100% utilisation (1_000_000 ppm) to 10_000 bps', () => {
@@ -83,5 +88,89 @@ describe(calculateTotalEffectiveBorrowableAmount, () => {
         totalAvailableAmount: 5_000n,
       }),
     ).toBe(5_000n);
+  });
+});
+
+describe('calculateLoanToValueBps', () => {
+  it('returns 0 if totalCollateralBalanceUsd is 0', () => {
+    expect(
+      calculateLoanToValueBps({ totalBorrowAmountUsd: 100, totalCollateralBalanceUsd: 0 }),
+    ).toBe(0);
+  });
+
+  it('calculates loan to value in bps', () => {
+    expect(
+      calculateLoanToValueBps({ totalBorrowAmountUsd: 500, totalCollateralBalanceUsd: 1000 }),
+    ).toBe(5000);
+    expect(
+      calculateLoanToValueBps({ totalBorrowAmountUsd: 1000, totalCollateralBalanceUsd: 1000 }),
+    ).toBe(10000);
+    expect(
+      calculateLoanToValueBps({ totalBorrowAmountUsd: 0, totalCollateralBalanceUsd: 1000 }),
+    ).toBe(0);
+  });
+
+  it('handles floating point values', () => {
+    expect(
+      calculateLoanToValueBps({ totalBorrowAmountUsd: 250.5, totalCollateralBalanceUsd: 1000 }),
+    ).toBeCloseTo(2505);
+  });
+});
+
+describe('calculateBorrowPowerUsedBps', () => {
+  it('returns 0 if totalCollateralBalanceUsd is 0', () => {
+    expect(
+      calculateBorrowPowerUsedBps({
+        totalBorrowAmountUsd: 100,
+        totalCollateralBalanceUsd: 0,
+        thresholdDecimal: 0.79,
+      }),
+    ).toBe(0);
+  });
+
+  it('returns 0 if liquidationThresholdDecimal is 0', () => {
+    expect(
+      calculateBorrowPowerUsedBps({
+        totalBorrowAmountUsd: 100,
+        totalCollateralBalanceUsd: 1000,
+        thresholdDecimal: 0,
+      }),
+    ).toBe(0);
+  });
+
+  it('calculates borrow power used in bps', () => {
+    expect(
+      calculateBorrowPowerUsedBps({
+        totalBorrowAmountUsd: 850,
+        totalCollateralBalanceUsd: 1000,
+        thresholdDecimal: 0.79,
+      }),
+    ).toBe(10759);
+
+    expect(
+      calculateBorrowPowerUsedBps({
+        totalBorrowAmountUsd: 425,
+        totalCollateralBalanceUsd: 1000,
+        thresholdDecimal: 0.79,
+      }),
+    ).toBe(5379);
+
+    expect(
+      calculateBorrowPowerUsedBps({
+        totalBorrowAmountUsd: 0,
+        totalCollateralBalanceUsd: 1000,
+        thresholdDecimal: 0.79,
+      }),
+    ).toBe(0);
+  });
+
+  it('handles floating point values', () => {
+    expect(
+      calculateBorrowPowerUsedBps({
+        totalBorrowAmountUsd: 123.45,
+        totalCollateralBalanceUsd: 1000,
+        thresholdDecimal: 0.79,
+      }),
+    ).toBe(1562);
   });
 });

--- a/packages/utils/src/__tests__/number.test.ts
+++ b/packages/utils/src/__tests__/number.test.ts
@@ -1,8 +1,56 @@
 import { describe, expect, it } from 'vitest';
-import { hexEncodeNumber } from '../number';
+import { bigintMax, bigintMin, hexEncodeNumber } from '../number';
 
 describe(hexEncodeNumber, () => {
   it('encodes a number to a hex string', () => {
     expect(hexEncodeNumber(42)).toBe('0x2a');
+  });
+});
+
+describe(bigintMin, () => {
+  it('returns the single value when given one argument', () => {
+    expect(bigintMin(5n)).toBe(5n);
+  });
+
+  it('returns the smaller of two values', () => {
+    expect(bigintMin(3n, 7n)).toBe(3n);
+    expect(bigintMin(7n, 3n)).toBe(3n);
+  });
+
+  it('returns the value when both are equal', () => {
+    expect(bigintMin(4n, 4n)).toBe(4n);
+  });
+
+  it('handles negative values', () => {
+    expect(bigintMin(-1n, 1n)).toBe(-1n);
+    expect(bigintMin(-5n, -2n)).toBe(-5n);
+  });
+
+  it('returns the minimum across multiple arguments', () => {
+    expect(bigintMin(10n, 3n, 7n, 1n, 5n)).toBe(1n);
+  });
+});
+
+describe(bigintMax, () => {
+  it('returns the single value when given one argument', () => {
+    expect(bigintMax(5n)).toBe(5n);
+  });
+
+  it('returns the larger of two values', () => {
+    expect(bigintMax(3n, 7n)).toBe(7n);
+    expect(bigintMax(7n, 3n)).toBe(7n);
+  });
+
+  it('returns the value when both are equal', () => {
+    expect(bigintMax(4n, 4n)).toBe(4n);
+  });
+
+  it('handles negative values', () => {
+    expect(bigintMax(-1n, 1n)).toBe(1n);
+    expect(bigintMax(-5n, -2n)).toBe(-2n);
+  });
+
+  it('returns the maximum across multiple arguments', () => {
+    expect(bigintMax(10n, 3n, 7n, 1n, 5n)).toBe(10n);
   });
 });

--- a/packages/utils/src/lending.ts
+++ b/packages/utils/src/lending.ts
@@ -1,0 +1,23 @@
+import BigNumber from 'bignumber.js';
+import { bigintMax } from './number.js';
+
+// Parts per million to basis points
+export const ppmToBps = (ppmAmount: number) => Math.trunc(ppmAmount / 100);
+
+export const calculateTotalEffectiveBorrowableAmount = ({
+  totalAmount,
+  totalAvailableAmount,
+  utilisationCap,
+}: {
+  totalAmount: bigint;
+  totalAvailableAmount: bigint;
+  utilisationCap?: number | null;
+}) => {
+  const totalBorrowedAmount = totalAmount - totalAvailableAmount;
+  const totalEffectiveBorrowableAmount = new BigNumber(totalAmount)
+    .multipliedBy(ppmToBps(utilisationCap ?? 1_000_000))
+    .div(10_000)
+    .toFixed();
+
+  return bigintMax(BigInt(totalEffectiveBorrowableAmount) - totalBorrowedAmount, 0n);
+};

--- a/packages/utils/src/lending.ts
+++ b/packages/utils/src/lending.ts
@@ -3,6 +3,34 @@ import { bigintMax } from './number.js';
 
 // Parts per million to basis points
 export const ppmToBps = (ppmAmount: number) => Math.trunc(ppmAmount / 100);
+// Parts per million to decimal
+export const ppmToDecimal = (ppmAmount: number) => ppmAmount / 1_000_000;
+
+export const calculateLoanToValueBps = ({
+  totalBorrowAmountUsd,
+  totalCollateralBalanceUsd,
+}: {
+  totalBorrowAmountUsd: number;
+  totalCollateralBalanceUsd: number;
+}) => {
+  if (totalCollateralBalanceUsd === 0) return 0;
+  return Math.trunc((totalBorrowAmountUsd / totalCollateralBalanceUsd) * 10_000);
+};
+
+export const calculateBorrowPowerUsedBps = ({
+  totalBorrowAmountUsd,
+  totalCollateralBalanceUsd,
+  thresholdDecimal,
+}: {
+  totalBorrowAmountUsd: number;
+  totalCollateralBalanceUsd: number;
+  thresholdDecimal: number; // 0.80 for example
+}) => {
+  if (totalCollateralBalanceUsd === 0 || thresholdDecimal === 0) return 0;
+  return Math.trunc(
+    (totalBorrowAmountUsd / (totalCollateralBalanceUsd * thresholdDecimal)) * 10_000,
+  );
+};
 
 export const calculateTotalEffectiveBorrowableAmount = ({
   totalAmount,

--- a/packages/utils/src/lending.ts
+++ b/packages/utils/src/lending.ts
@@ -35,15 +35,15 @@ export const calculateBorrowPowerUsedBps = ({
 export const calculateTotalEffectiveBorrowableAmount = ({
   totalAmount,
   totalAvailableAmount,
-  utilisationCap,
+  utilisationCapBps,
 }: {
   totalAmount: bigint;
   totalAvailableAmount: bigint;
-  utilisationCap?: number | null;
+  utilisationCapBps?: number | null; // 10_000 for 100%, for example
 }) => {
   const totalBorrowedAmount = totalAmount - totalAvailableAmount;
   const totalEffectiveBorrowableAmount = new BigNumber(totalAmount)
-    .multipliedBy(ppmToBps(utilisationCap ?? 1_000_000))
+    .multipliedBy(utilisationCapBps ?? 10_000)
     .div(10_000)
     .toFixed();
 

--- a/packages/utils/src/number.ts
+++ b/packages/utils/src/number.ts
@@ -1,3 +1,9 @@
 import { type HexString } from './types';
 
 export const hexEncodeNumber = (num: number | bigint): HexString => `0x${num.toString(16)}`;
+
+export const bigintMin = (...args: bigint[]): bigint =>
+  args.reduce((min, current) => (current < min ? current : min));
+
+export const bigintMax = (...args: bigint[]): bigint =>
+  args.reduce((max, current) => (current > max ? current : max));


### PR DESCRIPTION
Moved some of the common utils we use across our codebases wrt lending/numbers.

Introduced a new method `calculateTotalEffectiveBorrowableAmount`: https://github.com/chainflip-io/chainflip-product-toolkit/pull/1088#discussion_r3280540332