### PR TITLE
feat: added event name info to the generated schema

### DIFF
--- a/packages/chainspec/src/BaseCodeGenerator.ts
+++ b/packages/chainspec/src/BaseCodeGenerator.ts
@@ -192,6 +192,19 @@ export default abstract class CodeGenerator {
     return itemName;
   }
 
+  /**
+   * The exports to emit for one generated item. Default: just the item itself.
+   * Overridable so subclasses can emit companion exports (e.g. an event
+   * descriptor) alongside it. Only applied to per-item modules, not `common`.
+   */
+  protected itemExports(
+    name: string,
+    code: CodegenResult,
+    _parserName: string,
+  ): Map<string, CodegenResult> {
+    return new Map([[name, code]]);
+  }
+
   *generate(def: ParsedMetadata) {
     const unhandledItems = new Set(this.trackedItems);
     const generatedItems = new Set<string>();
@@ -217,7 +230,7 @@ export default abstract class CodeGenerator {
 
         yield new Module(
           this.getFileName(palletName, itemName),
-          new Map([[name, generatedCode]]),
+          this.itemExports(name, generatedCode, parserName),
           this.getGlobalImports(),
           palletName,
         );

--- a/packages/processor/README.MD
+++ b/packages/processor/README.MD
@@ -1,4 +1,4 @@
-### Processor Codegen
+# Processor Codegen
 
 The codegen utility is very useful in times of network runtime upgrades.
 In such scenarios, things can break on our end as our backends rely heavily on the events
@@ -7,9 +7,9 @@ This utility was written to help us spot new events as well as changes in the sc
 
 ---
 
-#### How to run for a new version
+## How to run for a new version
 
-To be able to run the code generation tool, you first need to find out the new spec version of the network and the block hash at which it occured. Once you have these 2 pieces of information, you need to update the [configuration file](../chainspec/metadata/specVersion.json) by adding the new spec verson together with the environment, like so:
+To be able to run the code generation tool, you first need to find out the new spec version of the network and the block hash at which it occurred. Once you have these 2 pieces of information, you need to update the [configuration file](../chainspec/metadata/specVersion.json) by adding the new spec version together with the environment, like so:
 
 ```json
 {
@@ -21,11 +21,11 @@ To be able to run the code generation tool, you first need to find out the new s
 }
 ```
 
-We just specified that we want to run the codegen for spec version "170" (1.7.0) and the upgrade occured at block hash `0xd9eeefdbd275bf7466b9d76c810a7ebfb1aab16a68301ee1ab605015c7295e95` on the backspin (our devnet) environment.
+We just specified that we want to run the codegen for spec version "170" (1.7.0) and the upgrade occurred at block hash `0xd9eeefdbd275bf7466b9d76c810a7ebfb1aab16a68301ee1ab605015c7295e95` on the backspin (our devnet) environment.
 
 Once this is done, save the file and run the [script](./scripts/generate.ts).
 
-```
+```sh
 ./scripts/generate.ts
 ```
 
@@ -33,7 +33,7 @@ Voila! You should see the auto-generated code inserted in the respective places.
 
 ---
 
-### How to re-run for the same version
+## How to re-run for the same version
 
 1. Remove the `packages/chainspec/metadata/{version}.scale` file.
 2. Remove the `packages/processor/generated/types-{version}.json` file.

--- a/packages/processor/generated/220/arbitrumBroadcaster/callResigned.ts
+++ b/packages/processor/generated/220/arbitrumBroadcaster/callResigned.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { cfChainsEvmTransaction } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const arbitrumBroadcasterCallResigned = z.object({
   broadcastId: z.number(),
   transactionPayload: cfChainsEvmTransaction,
 });
+
+export const arbitrumBroadcasterCallResignedEvent = defineEvent(
+  'ArbitrumBroadcaster.CallResigned',
+  arbitrumBroadcasterCallResigned,
+);

--- a/packages/processor/generated/220/arbitrumIngressEgress/batchBroadcastRequested.ts
+++ b/packages/processor/generated/220/arbitrumIngressEgress/batchBroadcastRequested.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsForeignChain, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const arbitrumIngressEgressBatchBroadcastRequested = z.object({
   broadcastId: z.number(),
   egressIds: z.array(z.tuple([cfPrimitivesChainsForeignChain, numberOrHex])),
 });
+
+export const arbitrumIngressEgressBatchBroadcastRequestedEvent = defineEvent(
+  'ArbitrumIngressEgress.BatchBroadcastRequested',
+  arbitrumIngressEgressBatchBroadcastRequested,
+);

--- a/packages/processor/generated/220/arbitrumIngressEgress/ccmBroadcastRequested.ts
+++ b/packages/processor/generated/220/arbitrumIngressEgress/ccmBroadcastRequested.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsForeignChain, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const arbitrumIngressEgressCcmBroadcastRequested = z.object({
   broadcastId: z.number(),
   egressId: z.tuple([cfPrimitivesChainsForeignChain, numberOrHex]),
 });
+
+export const arbitrumIngressEgressCcmBroadcastRequestedEvent = defineEvent(
+  'ArbitrumIngressEgress.CcmBroadcastRequested',
+  arbitrumIngressEgressCcmBroadcastRequested,
+);

--- a/packages/processor/generated/220/arbitrumIngressEgress/ccmEgressInvalid.ts
+++ b/packages/processor/generated/220/arbitrumIngressEgress/ccmEgressInvalid.ts
@@ -4,8 +4,14 @@ import {
   cfPrimitivesChainsForeignChain,
   numberOrHex,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const arbitrumIngressEgressCcmEgressInvalid = z.object({
   egressId: z.tuple([cfPrimitivesChainsForeignChain, numberOrHex]),
   error: cfChainsExecutexSwapAndCallError,
 });
+
+export const arbitrumIngressEgressCcmEgressInvalidEvent = defineEvent(
+  'ArbitrumIngressEgress.CcmEgressInvalid',
+  arbitrumIngressEgressCcmEgressInvalid,
+);

--- a/packages/processor/generated/220/arbitrumIngressEgress/depositBoosted.ts
+++ b/packages/processor/generated/220/arbitrumIngressEgress/depositBoosted.ts
@@ -8,6 +8,7 @@ import {
   numberOrHex,
   palletCfArbitrumIngressEgressDepositAction,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const arbitrumIngressEgressDepositBoosted = z.object({
   depositAddress: hexString.nullish(),
@@ -23,3 +24,8 @@ export const arbitrumIngressEgressDepositBoosted = z.object({
   action: palletCfArbitrumIngressEgressDepositAction,
   originType: cfChainsDepositOriginType,
 });
+
+export const arbitrumIngressEgressDepositBoostedEvent = defineEvent(
+  'ArbitrumIngressEgress.DepositBoosted',
+  arbitrumIngressEgressDepositBoosted,
+);

--- a/packages/processor/generated/220/arbitrumIngressEgress/depositFailed.ts
+++ b/packages/processor/generated/220/arbitrumIngressEgress/depositFailed.ts
@@ -4,9 +4,15 @@ import {
   palletCfArbitrumIngressEgressDepositFailedDetailsArbitrum,
   palletCfArbitrumIngressEgressDepositFailedReason,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const arbitrumIngressEgressDepositFailed = z.object({
   blockHeight: numberOrHex,
   reason: palletCfArbitrumIngressEgressDepositFailedReason,
   details: palletCfArbitrumIngressEgressDepositFailedDetailsArbitrum,
 });
+
+export const arbitrumIngressEgressDepositFailedEvent = defineEvent(
+  'ArbitrumIngressEgress.DepositFailed',
+  arbitrumIngressEgressDepositFailed,
+);

--- a/packages/processor/generated/220/arbitrumIngressEgress/depositFinalised.ts
+++ b/packages/processor/generated/220/arbitrumIngressEgress/depositFinalised.ts
@@ -7,6 +7,7 @@ import {
   numberOrHex,
   palletCfArbitrumIngressEgressDepositAction,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const arbitrumIngressEgressDepositFinalised = z.object({
   depositAddress: hexString.nullish(),
@@ -20,3 +21,8 @@ export const arbitrumIngressEgressDepositFinalised = z.object({
   channelId: numberOrHex.nullish(),
   originType: cfChainsDepositOriginType,
 });
+
+export const arbitrumIngressEgressDepositFinalisedEvent = defineEvent(
+  'ArbitrumIngressEgress.DepositFinalised',
+  arbitrumIngressEgressDepositFinalised,
+);

--- a/packages/processor/generated/220/arbitrumIngressEgress/transferFallbackRequested.ts
+++ b/packages/processor/generated/220/arbitrumIngressEgress/transferFallbackRequested.ts
@@ -5,6 +5,7 @@ import {
   hexString,
   numberOrHex,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const arbitrumIngressEgressTransferFallbackRequested = z.object({
   asset: cfPrimitivesChainsAssetsArbAsset,
@@ -13,3 +14,8 @@ export const arbitrumIngressEgressTransferFallbackRequested = z.object({
   broadcastId: z.number(),
   egressDetails: cfTraitsScheduledEgressDetailsArbitrum.nullish(),
 });
+
+export const arbitrumIngressEgressTransferFallbackRequestedEvent = defineEvent(
+  'ArbitrumIngressEgress.TransferFallbackRequested',
+  arbitrumIngressEgressTransferFallbackRequested,
+);

--- a/packages/processor/generated/220/assetBalances/accountCredited.ts
+++ b/packages/processor/generated/220/assetBalances/accountCredited.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { accountId, cfPrimitivesChainsAssetsAnyAsset, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const assetBalancesAccountCredited = z.object({
   accountId,
@@ -7,3 +8,8 @@ export const assetBalancesAccountCredited = z.object({
   amountCredited: numberOrHex,
   newBalance: numberOrHex,
 });
+
+export const assetBalancesAccountCreditedEvent = defineEvent(
+  'AssetBalances.AccountCredited',
+  assetBalancesAccountCredited,
+);

--- a/packages/processor/generated/220/assetBalances/accountDebited.ts
+++ b/packages/processor/generated/220/assetBalances/accountDebited.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { accountId, cfPrimitivesChainsAssetsAnyAsset, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const assetBalancesAccountDebited = z.object({
   accountId,
@@ -7,3 +8,8 @@ export const assetBalancesAccountDebited = z.object({
   amountDebited: numberOrHex,
   newBalance: numberOrHex,
 });
+
+export const assetBalancesAccountDebitedEvent = defineEvent(
+  'AssetBalances.AccountDebited',
+  assetBalancesAccountDebited,
+);

--- a/packages/processor/generated/220/assetBalances/refundScheduled.ts
+++ b/packages/processor/generated/220/assetBalances/refundScheduled.ts
@@ -4,9 +4,15 @@ import {
   cfPrimitivesChainsForeignChain,
   numberOrHex,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const assetBalancesRefundScheduled = z.object({
   egressId: z.tuple([cfPrimitivesChainsForeignChain, numberOrHex]),
   destination: cfChainsAddressForeignChainAddress,
   amount: numberOrHex,
 });
+
+export const assetBalancesRefundScheduledEvent = defineEvent(
+  'AssetBalances.RefundScheduled',
+  assetBalancesRefundScheduled,
+);

--- a/packages/processor/generated/220/assetBalances/refundSkipped.ts
+++ b/packages/processor/generated/220/assetBalances/refundSkipped.ts
@@ -4,9 +4,15 @@ import {
   cfPrimitivesChainsForeignChain,
   spRuntimeDispatchError,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const assetBalancesRefundSkipped = z.object({
   reason: spRuntimeDispatchError,
   chain: cfPrimitivesChainsForeignChain,
   address: cfChainsAddressForeignChainAddress,
 });
+
+export const assetBalancesRefundSkippedEvent = defineEvent(
+  'AssetBalances.RefundSkipped',
+  assetBalancesRefundSkipped,
+);

--- a/packages/processor/generated/220/assetBalances/vaultDeficitDetected.ts
+++ b/packages/processor/generated/220/assetBalances/vaultDeficitDetected.ts
@@ -1,8 +1,14 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsForeignChain, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const assetBalancesVaultDeficitDetected = z.object({
   chain: cfPrimitivesChainsForeignChain,
   amountOwed: numberOrHex,
   available: numberOrHex,
 });
+
+export const assetBalancesVaultDeficitDetectedEvent = defineEvent(
+  'AssetBalances.VaultDeficitDetected',
+  assetBalancesVaultDeficitDetected,
+);

--- a/packages/processor/generated/220/assethubBroadcaster/callResigned.ts
+++ b/packages/processor/generated/220/assethubBroadcaster/callResigned.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { cfChainsDotPolkadotTransactionData } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const assethubBroadcasterCallResigned = z.object({
   broadcastId: z.number(),
   transactionPayload: cfChainsDotPolkadotTransactionData,
 });
+
+export const assethubBroadcasterCallResignedEvent = defineEvent(
+  'AssethubBroadcaster.CallResigned',
+  assethubBroadcasterCallResigned,
+);

--- a/packages/processor/generated/220/assethubIngressEgress/batchBroadcastRequested.ts
+++ b/packages/processor/generated/220/assethubIngressEgress/batchBroadcastRequested.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsForeignChain, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const assethubIngressEgressBatchBroadcastRequested = z.object({
   broadcastId: z.number(),
   egressIds: z.array(z.tuple([cfPrimitivesChainsForeignChain, numberOrHex])),
 });
+
+export const assethubIngressEgressBatchBroadcastRequestedEvent = defineEvent(
+  'AssethubIngressEgress.BatchBroadcastRequested',
+  assethubIngressEgressBatchBroadcastRequested,
+);

--- a/packages/processor/generated/220/assethubIngressEgress/ccmBroadcastRequested.ts
+++ b/packages/processor/generated/220/assethubIngressEgress/ccmBroadcastRequested.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsForeignChain, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const assethubIngressEgressCcmBroadcastRequested = z.object({
   broadcastId: z.number(),
   egressId: z.tuple([cfPrimitivesChainsForeignChain, numberOrHex]),
 });
+
+export const assethubIngressEgressCcmBroadcastRequestedEvent = defineEvent(
+  'AssethubIngressEgress.CcmBroadcastRequested',
+  assethubIngressEgressCcmBroadcastRequested,
+);

--- a/packages/processor/generated/220/assethubIngressEgress/ccmEgressInvalid.ts
+++ b/packages/processor/generated/220/assethubIngressEgress/ccmEgressInvalid.ts
@@ -4,8 +4,14 @@ import {
   cfPrimitivesChainsForeignChain,
   numberOrHex,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const assethubIngressEgressCcmEgressInvalid = z.object({
   egressId: z.tuple([cfPrimitivesChainsForeignChain, numberOrHex]),
   error: cfChainsExecutexSwapAndCallError,
 });
+
+export const assethubIngressEgressCcmEgressInvalidEvent = defineEvent(
+  'AssethubIngressEgress.CcmEgressInvalid',
+  assethubIngressEgressCcmEgressInvalid,
+);

--- a/packages/processor/generated/220/assethubIngressEgress/depositBoosted.ts
+++ b/packages/processor/generated/220/assethubIngressEgress/depositBoosted.ts
@@ -7,6 +7,7 @@ import {
   numberOrHex,
   palletCfAssethubIngressEgressDepositAction,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const assethubIngressEgressDepositBoosted = z.object({
   depositAddress: hexString.nullish(),
@@ -22,3 +23,8 @@ export const assethubIngressEgressDepositBoosted = z.object({
   action: palletCfAssethubIngressEgressDepositAction,
   originType: cfChainsDepositOriginType,
 });
+
+export const assethubIngressEgressDepositBoostedEvent = defineEvent(
+  'AssethubIngressEgress.DepositBoosted',
+  assethubIngressEgressDepositBoosted,
+);

--- a/packages/processor/generated/220/assethubIngressEgress/depositFailed.ts
+++ b/packages/processor/generated/220/assethubIngressEgress/depositFailed.ts
@@ -3,9 +3,15 @@ import {
   palletCfAssethubIngressEgressDepositFailedDetailsAssethub,
   palletCfAssethubIngressEgressDepositFailedReason,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const assethubIngressEgressDepositFailed = z.object({
   blockHeight: z.number(),
   reason: palletCfAssethubIngressEgressDepositFailedReason,
   details: palletCfAssethubIngressEgressDepositFailedDetailsAssethub,
 });
+
+export const assethubIngressEgressDepositFailedEvent = defineEvent(
+  'AssethubIngressEgress.DepositFailed',
+  assethubIngressEgressDepositFailed,
+);

--- a/packages/processor/generated/220/assethubIngressEgress/depositFinalised.ts
+++ b/packages/processor/generated/220/assethubIngressEgress/depositFinalised.ts
@@ -6,6 +6,7 @@ import {
   numberOrHex,
   palletCfAssethubIngressEgressDepositAction,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const assethubIngressEgressDepositFinalised = z.object({
   depositAddress: hexString.nullish(),
@@ -19,3 +20,8 @@ export const assethubIngressEgressDepositFinalised = z.object({
   channelId: numberOrHex.nullish(),
   originType: cfChainsDepositOriginType,
 });
+
+export const assethubIngressEgressDepositFinalisedEvent = defineEvent(
+  'AssethubIngressEgress.DepositFinalised',
+  assethubIngressEgressDepositFinalised,
+);

--- a/packages/processor/generated/220/assethubIngressEgress/transferFallbackRequested.ts
+++ b/packages/processor/generated/220/assethubIngressEgress/transferFallbackRequested.ts
@@ -5,6 +5,7 @@ import {
   hexString,
   numberOrHex,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const assethubIngressEgressTransferFallbackRequested = z.object({
   asset: cfPrimitivesChainsAssetsHubAsset,
@@ -13,3 +14,8 @@ export const assethubIngressEgressTransferFallbackRequested = z.object({
   broadcastId: z.number(),
   egressDetails: cfTraitsScheduledEgressDetailsAssethub.nullish(),
 });
+
+export const assethubIngressEgressTransferFallbackRequestedEvent = defineEvent(
+  'AssethubIngressEgress.TransferFallbackRequested',
+  assethubIngressEgressTransferFallbackRequested,
+);

--- a/packages/processor/generated/220/bitcoinBroadcaster/callResigned.ts
+++ b/packages/processor/generated/220/bitcoinBroadcaster/callResigned.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { cfChainsBtcBitcoinTransactionData } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const bitcoinBroadcasterCallResigned = z.object({
   broadcastId: z.number(),
   transactionPayload: cfChainsBtcBitcoinTransactionData,
 });
+
+export const bitcoinBroadcasterCallResignedEvent = defineEvent(
+  'BitcoinBroadcaster.CallResigned',
+  bitcoinBroadcasterCallResigned,
+);

--- a/packages/processor/generated/220/bitcoinIngressEgress/batchBroadcastRequested.ts
+++ b/packages/processor/generated/220/bitcoinIngressEgress/batchBroadcastRequested.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsForeignChain, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const bitcoinIngressEgressBatchBroadcastRequested = z.object({
   broadcastId: z.number(),
   egressIds: z.array(z.tuple([cfPrimitivesChainsForeignChain, numberOrHex])),
 });
+
+export const bitcoinIngressEgressBatchBroadcastRequestedEvent = defineEvent(
+  'BitcoinIngressEgress.BatchBroadcastRequested',
+  bitcoinIngressEgressBatchBroadcastRequested,
+);

--- a/packages/processor/generated/220/bitcoinIngressEgress/ccmBroadcastRequested.ts
+++ b/packages/processor/generated/220/bitcoinIngressEgress/ccmBroadcastRequested.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsForeignChain, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const bitcoinIngressEgressCcmBroadcastRequested = z.object({
   broadcastId: z.number(),
   egressId: z.tuple([cfPrimitivesChainsForeignChain, numberOrHex]),
 });
+
+export const bitcoinIngressEgressCcmBroadcastRequestedEvent = defineEvent(
+  'BitcoinIngressEgress.CcmBroadcastRequested',
+  bitcoinIngressEgressCcmBroadcastRequested,
+);

--- a/packages/processor/generated/220/bitcoinIngressEgress/ccmEgressInvalid.ts
+++ b/packages/processor/generated/220/bitcoinIngressEgress/ccmEgressInvalid.ts
@@ -4,8 +4,14 @@ import {
   cfPrimitivesChainsForeignChain,
   numberOrHex,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const bitcoinIngressEgressCcmEgressInvalid = z.object({
   egressId: z.tuple([cfPrimitivesChainsForeignChain, numberOrHex]),
   error: cfChainsExecutexSwapAndCallError,
 });
+
+export const bitcoinIngressEgressCcmEgressInvalidEvent = defineEvent(
+  'BitcoinIngressEgress.CcmEgressInvalid',
+  bitcoinIngressEgressCcmEgressInvalid,
+);

--- a/packages/processor/generated/220/bitcoinIngressEgress/depositBoosted.ts
+++ b/packages/processor/generated/220/bitcoinIngressEgress/depositBoosted.ts
@@ -8,6 +8,7 @@ import {
   numberOrHex,
   palletCfBitcoinIngressEgressDepositAction,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const bitcoinIngressEgressDepositBoosted = z.object({
   depositAddress: cfChainsBtcScriptPubkey.nullish(),
@@ -23,3 +24,8 @@ export const bitcoinIngressEgressDepositBoosted = z.object({
   action: palletCfBitcoinIngressEgressDepositAction,
   originType: cfChainsDepositOriginType,
 });
+
+export const bitcoinIngressEgressDepositBoostedEvent = defineEvent(
+  'BitcoinIngressEgress.DepositBoosted',
+  bitcoinIngressEgressDepositBoosted,
+);

--- a/packages/processor/generated/220/bitcoinIngressEgress/depositFailed.ts
+++ b/packages/processor/generated/220/bitcoinIngressEgress/depositFailed.ts
@@ -4,9 +4,15 @@ import {
   palletCfBitcoinIngressEgressDepositFailedDetailsBitcoin,
   palletCfBitcoinIngressEgressDepositFailedReason,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const bitcoinIngressEgressDepositFailed = z.object({
   blockHeight: numberOrHex,
   reason: palletCfBitcoinIngressEgressDepositFailedReason,
   details: palletCfBitcoinIngressEgressDepositFailedDetailsBitcoin,
 });
+
+export const bitcoinIngressEgressDepositFailedEvent = defineEvent(
+  'BitcoinIngressEgress.DepositFailed',
+  bitcoinIngressEgressDepositFailed,
+);

--- a/packages/processor/generated/220/bitcoinIngressEgress/depositFinalised.ts
+++ b/packages/processor/generated/220/bitcoinIngressEgress/depositFinalised.ts
@@ -7,6 +7,7 @@ import {
   numberOrHex,
   palletCfBitcoinIngressEgressDepositAction,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const bitcoinIngressEgressDepositFinalised = z.object({
   depositAddress: cfChainsBtcScriptPubkey.nullish(),
@@ -20,3 +21,8 @@ export const bitcoinIngressEgressDepositFinalised = z.object({
   channelId: numberOrHex.nullish(),
   originType: cfChainsDepositOriginType,
 });
+
+export const bitcoinIngressEgressDepositFinalisedEvent = defineEvent(
+  'BitcoinIngressEgress.DepositFinalised',
+  bitcoinIngressEgressDepositFinalised,
+);

--- a/packages/processor/generated/220/bitcoinIngressEgress/transferFallbackRequested.ts
+++ b/packages/processor/generated/220/bitcoinIngressEgress/transferFallbackRequested.ts
@@ -5,6 +5,7 @@ import {
   cfTraitsScheduledEgressDetailsBitcoin,
   numberOrHex,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const bitcoinIngressEgressTransferFallbackRequested = z.object({
   asset: cfPrimitivesChainsAssetsBtcAsset,
@@ -13,3 +14,8 @@ export const bitcoinIngressEgressTransferFallbackRequested = z.object({
   broadcastId: z.number(),
   egressDetails: cfTraitsScheduledEgressDetailsBitcoin.nullish(),
 });
+
+export const bitcoinIngressEgressTransferFallbackRequestedEvent = defineEvent(
+  'BitcoinIngressEgress.TransferFallbackRequested',
+  bitcoinIngressEgressTransferFallbackRequested,
+);

--- a/packages/processor/generated/220/emissions/networkFeeBurned.ts
+++ b/packages/processor/generated/220/emissions/networkFeeBurned.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsForeignChain, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const emissionsNetworkFeeBurned = z.object({
   amount: numberOrHex,
   egressId: z.tuple([cfPrimitivesChainsForeignChain, numberOrHex]),
 });
+
+export const emissionsNetworkFeeBurnedEvent = defineEvent(
+  'Emissions.NetworkFeeBurned',
+  emissionsNetworkFeeBurned,
+);

--- a/packages/processor/generated/220/environment/runtimeSafeModeUpdated.ts
+++ b/packages/processor/generated/220/environment/runtimeSafeModeUpdated.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 import { palletCfEnvironmentSafeModeUpdate } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const environmentRuntimeSafeModeUpdated = z.object({
   safeMode: palletCfEnvironmentSafeModeUpdate,
 });
+
+export const environmentRuntimeSafeModeUpdatedEvent = defineEvent(
+  'Environment.RuntimeSafeModeUpdated',
+  environmentRuntimeSafeModeUpdated,
+);

--- a/packages/processor/generated/220/environment/tronInitialized.ts
+++ b/packages/processor/generated/220/environment/tronInitialized.ts
@@ -1,3 +1,9 @@
 import { z } from 'zod';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const environmentTronInitialized = z.null();
+
+export const environmentTronInitializedEvent = defineEvent(
+  'Environment.TronInitialized',
+  environmentTronInitialized,
+);

--- a/packages/processor/generated/220/ethereumBroadcaster/callResigned.ts
+++ b/packages/processor/generated/220/ethereumBroadcaster/callResigned.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { cfChainsEvmTransaction } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const ethereumBroadcasterCallResigned = z.object({
   broadcastId: z.number(),
   transactionPayload: cfChainsEvmTransaction,
 });
+
+export const ethereumBroadcasterCallResignedEvent = defineEvent(
+  'EthereumBroadcaster.CallResigned',
+  ethereumBroadcasterCallResigned,
+);

--- a/packages/processor/generated/220/ethereumIngressEgress/batchBroadcastRequested.ts
+++ b/packages/processor/generated/220/ethereumIngressEgress/batchBroadcastRequested.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsForeignChain, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const ethereumIngressEgressBatchBroadcastRequested = z.object({
   broadcastId: z.number(),
   egressIds: z.array(z.tuple([cfPrimitivesChainsForeignChain, numberOrHex])),
 });
+
+export const ethereumIngressEgressBatchBroadcastRequestedEvent = defineEvent(
+  'EthereumIngressEgress.BatchBroadcastRequested',
+  ethereumIngressEgressBatchBroadcastRequested,
+);

--- a/packages/processor/generated/220/ethereumIngressEgress/ccmBroadcastRequested.ts
+++ b/packages/processor/generated/220/ethereumIngressEgress/ccmBroadcastRequested.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsForeignChain, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const ethereumIngressEgressCcmBroadcastRequested = z.object({
   broadcastId: z.number(),
   egressId: z.tuple([cfPrimitivesChainsForeignChain, numberOrHex]),
 });
+
+export const ethereumIngressEgressCcmBroadcastRequestedEvent = defineEvent(
+  'EthereumIngressEgress.CcmBroadcastRequested',
+  ethereumIngressEgressCcmBroadcastRequested,
+);

--- a/packages/processor/generated/220/ethereumIngressEgress/ccmEgressInvalid.ts
+++ b/packages/processor/generated/220/ethereumIngressEgress/ccmEgressInvalid.ts
@@ -4,8 +4,14 @@ import {
   cfPrimitivesChainsForeignChain,
   numberOrHex,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const ethereumIngressEgressCcmEgressInvalid = z.object({
   egressId: z.tuple([cfPrimitivesChainsForeignChain, numberOrHex]),
   error: cfChainsExecutexSwapAndCallError,
 });
+
+export const ethereumIngressEgressCcmEgressInvalidEvent = defineEvent(
+  'EthereumIngressEgress.CcmEgressInvalid',
+  ethereumIngressEgressCcmEgressInvalid,
+);

--- a/packages/processor/generated/220/ethereumIngressEgress/depositBoosted.ts
+++ b/packages/processor/generated/220/ethereumIngressEgress/depositBoosted.ts
@@ -8,6 +8,7 @@ import {
   numberOrHex,
   palletCfEthereumIngressEgressDepositAction,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const ethereumIngressEgressDepositBoosted = z.object({
   depositAddress: hexString.nullish(),
@@ -23,3 +24,8 @@ export const ethereumIngressEgressDepositBoosted = z.object({
   action: palletCfEthereumIngressEgressDepositAction,
   originType: cfChainsDepositOriginType,
 });
+
+export const ethereumIngressEgressDepositBoostedEvent = defineEvent(
+  'EthereumIngressEgress.DepositBoosted',
+  ethereumIngressEgressDepositBoosted,
+);

--- a/packages/processor/generated/220/ethereumIngressEgress/depositFailed.ts
+++ b/packages/processor/generated/220/ethereumIngressEgress/depositFailed.ts
@@ -4,9 +4,15 @@ import {
   palletCfEthereumIngressEgressDepositFailedDetailsEthereum,
   palletCfEthereumIngressEgressDepositFailedReason,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const ethereumIngressEgressDepositFailed = z.object({
   blockHeight: numberOrHex,
   reason: palletCfEthereumIngressEgressDepositFailedReason,
   details: palletCfEthereumIngressEgressDepositFailedDetailsEthereum,
 });
+
+export const ethereumIngressEgressDepositFailedEvent = defineEvent(
+  'EthereumIngressEgress.DepositFailed',
+  ethereumIngressEgressDepositFailed,
+);

--- a/packages/processor/generated/220/ethereumIngressEgress/depositFinalised.ts
+++ b/packages/processor/generated/220/ethereumIngressEgress/depositFinalised.ts
@@ -7,6 +7,7 @@ import {
   numberOrHex,
   palletCfEthereumIngressEgressDepositAction,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const ethereumIngressEgressDepositFinalised = z.object({
   depositAddress: hexString.nullish(),
@@ -20,3 +21,8 @@ export const ethereumIngressEgressDepositFinalised = z.object({
   channelId: numberOrHex.nullish(),
   originType: cfChainsDepositOriginType,
 });
+
+export const ethereumIngressEgressDepositFinalisedEvent = defineEvent(
+  'EthereumIngressEgress.DepositFinalised',
+  ethereumIngressEgressDepositFinalised,
+);

--- a/packages/processor/generated/220/ethereumIngressEgress/transferFallbackRequested.ts
+++ b/packages/processor/generated/220/ethereumIngressEgress/transferFallbackRequested.ts
@@ -5,6 +5,7 @@ import {
   hexString,
   numberOrHex,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const ethereumIngressEgressTransferFallbackRequested = z.object({
   asset: cfPrimitivesChainsAssetsEthAsset,
@@ -13,3 +14,8 @@ export const ethereumIngressEgressTransferFallbackRequested = z.object({
   broadcastId: z.number(),
   egressDetails: cfTraitsScheduledEgressDetailsEthereum.nullish(),
 });
+
+export const ethereumIngressEgressTransferFallbackRequestedEvent = defineEvent(
+  'EthereumIngressEgress.TransferFallbackRequested',
+  ethereumIngressEgressTransferFallbackRequested,
+);

--- a/packages/processor/generated/220/funding/funded.ts
+++ b/packages/processor/generated/220/funding/funded.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { accountId, cfTraitsFundingSource, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const fundingFunded = z.object({
   accountId,
@@ -7,3 +8,5 @@ export const fundingFunded = z.object({
   fundsAdded: numberOrHex,
   totalBalance: numberOrHex,
 });
+
+export const fundingFundedEvent = defineEvent('Funding.Funded', fundingFunded);

--- a/packages/processor/generated/220/grandpa/grandpaVoteDelegated.ts
+++ b/packages/processor/generated/220/grandpa/grandpaVoteDelegated.ts
@@ -1,4 +1,10 @@
 import { z } from 'zod';
 import { hexString } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const grandpaGrandpaVoteDelegated = z.object({ delegator: hexString, delegate: hexString });
+
+export const grandpaGrandpaVoteDelegatedEvent = defineEvent(
+  'Grandpa.GrandpaVoteDelegated',
+  grandpaGrandpaVoteDelegated,
+);

--- a/packages/processor/generated/220/grandpa/grandpaVoteDelegationRemoved.ts
+++ b/packages/processor/generated/220/grandpa/grandpaVoteDelegationRemoved.ts
@@ -1,4 +1,10 @@
 import { z } from 'zod';
 import { hexString } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const grandpaGrandpaVoteDelegationRemoved = z.object({ delegator: hexString });
+
+export const grandpaGrandpaVoteDelegationRemovedEvent = defineEvent(
+  'Grandpa.GrandpaVoteDelegationRemoved',
+  grandpaGrandpaVoteDelegationRemoved,
+);

--- a/packages/processor/generated/220/lendingPools/boostFundsAdded.ts
+++ b/packages/processor/generated/220/lendingPools/boostFundsAdded.ts
@@ -1,8 +1,14 @@
 import { z } from 'zod';
 import { accountId, numberOrHex, palletCfLendingPoolsBoostBoostPoolId } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const lendingPoolsBoostFundsAdded = z.object({
   boosterId: accountId,
   boostPool: palletCfLendingPoolsBoostBoostPoolId,
   amount: numberOrHex,
 });
+
+export const lendingPoolsBoostFundsAddedEvent = defineEvent(
+  'LendingPools.BoostFundsAdded',
+  lendingPoolsBoostFundsAdded,
+);

--- a/packages/processor/generated/220/lendingPools/boostPoolCreated.ts
+++ b/packages/processor/generated/220/lendingPools/boostPoolCreated.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 import { palletCfLendingPoolsBoostBoostPoolId } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const lendingPoolsBoostPoolCreated = z.object({
   boostPool: palletCfLendingPoolsBoostBoostPoolId,
 });
+
+export const lendingPoolsBoostPoolCreatedEvent = defineEvent(
+  'LendingPools.BoostPoolCreated',
+  lendingPoolsBoostPoolCreated,
+);

--- a/packages/processor/generated/220/lendingPools/lendingFundsAdded.ts
+++ b/packages/processor/generated/220/lendingPools/lendingFundsAdded.ts
@@ -5,6 +5,7 @@ import {
   numberOrHex,
   palletCfLendingPoolsSupplyAddedActionType,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const lendingPoolsLendingFundsAdded = z.object({
   lenderId: accountId,
@@ -12,3 +13,8 @@ export const lendingPoolsLendingFundsAdded = z.object({
   amount: numberOrHex,
   actionType: palletCfLendingPoolsSupplyAddedActionType,
 });
+
+export const lendingPoolsLendingFundsAddedEvent = defineEvent(
+  'LendingPools.LendingFundsAdded',
+  lendingPoolsLendingFundsAdded,
+);

--- a/packages/processor/generated/220/lendingPools/lendingFundsRemoved.ts
+++ b/packages/processor/generated/220/lendingPools/lendingFundsRemoved.ts
@@ -5,6 +5,7 @@ import {
   numberOrHex,
   palletCfLendingPoolsSupplyRemovedActionType,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const lendingPoolsLendingFundsRemoved = z.object({
   lenderId: accountId,
@@ -12,3 +13,8 @@ export const lendingPoolsLendingFundsRemoved = z.object({
   unlockedAmount: numberOrHex,
   actionType: palletCfLendingPoolsSupplyRemovedActionType,
 });
+
+export const lendingPoolsLendingFundsRemovedEvent = defineEvent(
+  'LendingPools.LendingFundsRemoved',
+  lendingPoolsLendingFundsRemoved,
+);

--- a/packages/processor/generated/220/lendingPools/lendingPoolCreated.ts
+++ b/packages/processor/generated/220/lendingPools/lendingPoolCreated.ts
@@ -1,4 +1,10 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsAssetsAnyAsset } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const lendingPoolsLendingPoolCreated = z.object({ asset: cfPrimitivesChainsAssetsAnyAsset });
+
+export const lendingPoolsLendingPoolCreatedEvent = defineEvent(
+  'LendingPools.LendingPoolCreated',
+  lendingPoolsLendingPoolCreated,
+);

--- a/packages/processor/generated/220/lendingPools/loanCreated.ts
+++ b/packages/processor/generated/220/lendingPools/loanCreated.ts
@@ -5,6 +5,7 @@ import {
   numberOrHex,
   palletCfLendingPoolsGeneralLendingLoanType,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const lendingPoolsLoanCreated = z.object({
   loanId: numberOrHex,
@@ -13,3 +14,8 @@ export const lendingPoolsLoanCreated = z.object({
   principalAmount: numberOrHex,
   brokerId: accountId.nullish(),
 });
+
+export const lendingPoolsLoanCreatedEvent = defineEvent(
+  'LendingPools.LoanCreated',
+  lendingPoolsLoanCreated,
+);

--- a/packages/processor/generated/220/lendingPools/loanRepaid.ts
+++ b/packages/processor/generated/220/lendingPools/loanRepaid.ts
@@ -1,8 +1,14 @@
 import { z } from 'zod';
 import { numberOrHex, palletCfLendingPoolsLoanRepaidActionType } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const lendingPoolsLoanRepaid = z.object({
   loanId: numberOrHex,
   amount: numberOrHex,
   actionType: palletCfLendingPoolsLoanRepaidActionType,
 });
+
+export const lendingPoolsLoanRepaidEvent = defineEvent(
+  'LendingPools.LoanRepaid',
+  lendingPoolsLoanRepaid,
+);

--- a/packages/processor/generated/220/lendingPools/palletConfigUpdated.ts
+++ b/packages/processor/generated/220/lendingPools/palletConfigUpdated.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 import { palletCfLendingPoolsPalletConfigUpdate } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const lendingPoolsPalletConfigUpdated = z.object({
   update: palletCfLendingPoolsPalletConfigUpdate,
 });
+
+export const lendingPoolsPalletConfigUpdatedEvent = defineEvent(
+  'LendingPools.PalletConfigUpdated',
+  lendingPoolsPalletConfigUpdated,
+);

--- a/packages/processor/generated/220/lendingPools/stoppedBoosting.ts
+++ b/packages/processor/generated/220/lendingPools/stoppedBoosting.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { accountId, numberOrHex, palletCfLendingPoolsBoostBoostPoolId } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const lendingPoolsStoppedBoosting = z.object({
   boosterId: accountId,
@@ -7,3 +8,8 @@ export const lendingPoolsStoppedBoosting = z.object({
   unlockedAmount: numberOrHex,
   pendingBoosts: z.array(numberOrHex),
 });
+
+export const lendingPoolsStoppedBoostingEvent = defineEvent(
+  'LendingPools.StoppedBoosting',
+  lendingPoolsStoppedBoosting,
+);

--- a/packages/processor/generated/220/liquidityPools/assetSwapped.ts
+++ b/packages/processor/generated/220/liquidityPools/assetSwapped.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsAssetsAnyAsset, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const liquidityPoolsAssetSwapped = z.object({
   from: cfPrimitivesChainsAssetsAnyAsset,
@@ -7,3 +8,8 @@ export const liquidityPoolsAssetSwapped = z.object({
   inputAmount: numberOrHex,
   outputAmount: numberOrHex,
 });
+
+export const liquidityPoolsAssetSwappedEvent = defineEvent(
+  'LiquidityPools.AssetSwapped',
+  liquidityPoolsAssetSwapped,
+);

--- a/packages/processor/generated/220/liquidityPools/limitOrderUpdated.ts
+++ b/packages/processor/generated/220/liquidityPools/limitOrderUpdated.ts
@@ -6,6 +6,7 @@ import {
   cfTraitsLiquidityIncreaseOrDecreaseU128,
   numberOrHex,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const liquidityPoolsLimitOrderUpdated = z.object({
   lp: accountId,
@@ -19,3 +20,8 @@ export const liquidityPoolsLimitOrderUpdated = z.object({
   collectedFees: numberOrHex,
   boughtAmount: numberOrHex,
 });
+
+export const liquidityPoolsLimitOrderUpdatedEvent = defineEvent(
+  'LiquidityPools.LimitOrderUpdated',
+  liquidityPoolsLimitOrderUpdated,
+);

--- a/packages/processor/generated/220/liquidityPools/newPoolCreated.ts
+++ b/packages/processor/generated/220/liquidityPools/newPoolCreated.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsAssetsAnyAsset, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const liquidityPoolsNewPoolCreated = z.object({
   baseAsset: cfPrimitivesChainsAssetsAnyAsset,
@@ -7,3 +8,8 @@ export const liquidityPoolsNewPoolCreated = z.object({
   feeHundredthPips: z.number(),
   initialPrice: numberOrHex,
 });
+
+export const liquidityPoolsNewPoolCreatedEvent = defineEvent(
+  'LiquidityPools.NewPoolCreated',
+  liquidityPoolsNewPoolCreated,
+);

--- a/packages/processor/generated/220/liquidityPools/orderDeletionFailed.ts
+++ b/packages/processor/generated/220/liquidityPools/orderDeletionFailed.ts
@@ -1,4 +1,10 @@
 import { z } from 'zod';
 import { palletCfPoolsCloseOrder } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const liquidityPoolsOrderDeletionFailed = z.object({ order: palletCfPoolsCloseOrder });
+
+export const liquidityPoolsOrderDeletionFailedEvent = defineEvent(
+  'LiquidityPools.OrderDeletionFailed',
+  liquidityPoolsOrderDeletionFailed,
+);

--- a/packages/processor/generated/220/liquidityPools/palletConfigUpdated.ts
+++ b/packages/processor/generated/220/liquidityPools/palletConfigUpdated.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 import { palletCfPoolsPalletConfigUpdate } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const liquidityPoolsPalletConfigUpdated = z.object({
   update: palletCfPoolsPalletConfigUpdate,
 });
+
+export const liquidityPoolsPalletConfigUpdatedEvent = defineEvent(
+  'LiquidityPools.PalletConfigUpdated',
+  liquidityPoolsPalletConfigUpdated,
+);

--- a/packages/processor/generated/220/liquidityPools/poolFeeSet.ts
+++ b/packages/processor/generated/220/liquidityPools/poolFeeSet.ts
@@ -1,8 +1,14 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsAssetsAnyAsset } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const liquidityPoolsPoolFeeSet = z.object({
   baseAsset: cfPrimitivesChainsAssetsAnyAsset,
   quoteAsset: cfPrimitivesChainsAssetsAnyAsset,
   feeHundredthPips: z.number(),
 });
+
+export const liquidityPoolsPoolFeeSetEvent = defineEvent(
+  'LiquidityPools.PoolFeeSet',
+  liquidityPoolsPoolFeeSet,
+);

--- a/packages/processor/generated/220/liquidityPools/priceImpactLimitSet.ts
+++ b/packages/processor/generated/220/liquidityPools/priceImpactLimitSet.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { cfAmmCommonAssetPair } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const liquidityPoolsPriceImpactLimitSet = z.object({
   assetPair: cfAmmCommonAssetPair,
   limit: z.number().nullish(),
 });
+
+export const liquidityPoolsPriceImpactLimitSetEvent = defineEvent(
+  'LiquidityPools.PriceImpactLimitSet',
+  liquidityPoolsPriceImpactLimitSet,
+);

--- a/packages/processor/generated/220/liquidityPools/rangeOrderUpdated.ts
+++ b/packages/processor/generated/220/liquidityPools/rangeOrderUpdated.ts
@@ -6,6 +6,7 @@ import {
   cfTraitsLiquidityIncreaseOrDecreaseRangeOrderChange,
   numberOrHex,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const liquidityPoolsRangeOrderUpdated = z.object({
   lp: accountId,
@@ -17,3 +18,8 @@ export const liquidityPoolsRangeOrderUpdated = z.object({
   liquidityTotal: numberOrHex,
   collectedFees: cfAmmCommonPoolPairsMap,
 });
+
+export const liquidityPoolsRangeOrderUpdatedEvent = defineEvent(
+  'LiquidityPools.RangeOrderUpdated',
+  liquidityPoolsRangeOrderUpdated,
+);

--- a/packages/processor/generated/220/liquidityProvider/assetBalancePurgeFailed.ts
+++ b/packages/processor/generated/220/liquidityProvider/assetBalancePurgeFailed.ts
@@ -5,6 +5,7 @@ import {
   numberOrHex,
   spRuntimeDispatchError,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const liquidityProviderAssetBalancePurgeFailed = z.object({
   accountId,
@@ -12,3 +13,8 @@ export const liquidityProviderAssetBalancePurgeFailed = z.object({
   amount: numberOrHex,
   error: spRuntimeDispatchError,
 });
+
+export const liquidityProviderAssetBalancePurgeFailedEvent = defineEvent(
+  'LiquidityProvider.AssetBalancePurgeFailed',
+  liquidityProviderAssetBalancePurgeFailed,
+);

--- a/packages/processor/generated/220/liquidityProvider/assetBalancePurged.ts
+++ b/packages/processor/generated/220/liquidityProvider/assetBalancePurged.ts
@@ -6,6 +6,7 @@ import {
   cfPrimitivesChainsForeignChain,
   numberOrHex,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const liquidityProviderAssetBalancePurged = z.object({
   accountId,
@@ -15,3 +16,8 @@ export const liquidityProviderAssetBalancePurged = z.object({
   destinationAddress: cfChainsAddressEncodedAddress,
   fee: numberOrHex,
 });
+
+export const liquidityProviderAssetBalancePurgedEvent = defineEvent(
+  'LiquidityProvider.AssetBalancePurged',
+  liquidityProviderAssetBalancePurged,
+);

--- a/packages/processor/generated/220/liquidityProvider/assetTransferred.ts
+++ b/packages/processor/generated/220/liquidityProvider/assetTransferred.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { accountId, cfPrimitivesChainsAssetsAnyAsset, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const liquidityProviderAssetTransferred = z.object({
   from: accountId,
@@ -7,3 +8,8 @@ export const liquidityProviderAssetTransferred = z.object({
   asset: cfPrimitivesChainsAssetsAnyAsset,
   amount: numberOrHex,
 });
+
+export const liquidityProviderAssetTransferredEvent = defineEvent(
+  'LiquidityProvider.AssetTransferred',
+  liquidityProviderAssetTransferred,
+);

--- a/packages/processor/generated/220/liquidityProvider/liquidityDepositAddressReady.ts
+++ b/packages/processor/generated/220/liquidityProvider/liquidityDepositAddressReady.ts
@@ -5,6 +5,7 @@ import {
   cfPrimitivesChainsAssetsAnyAsset,
   numberOrHex,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const liquidityProviderLiquidityDepositAddressReady = z.object({
   channelId: numberOrHex,
@@ -15,3 +16,8 @@ export const liquidityProviderLiquidityDepositAddressReady = z.object({
   boostFee: z.number(),
   channelOpeningFee: numberOrHex,
 });
+
+export const liquidityProviderLiquidityDepositAddressReadyEvent = defineEvent(
+  'LiquidityProvider.LiquidityDepositAddressReady',
+  liquidityProviderLiquidityDepositAddressReady,
+);

--- a/packages/processor/generated/220/liquidityProvider/liquidityRefundAddressRegistered.ts
+++ b/packages/processor/generated/220/liquidityProvider/liquidityRefundAddressRegistered.ts
@@ -4,9 +4,15 @@ import {
   cfChainsAddressForeignChainAddress,
   cfPrimitivesChainsForeignChain,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const liquidityProviderLiquidityRefundAddressRegistered = z.object({
   accountId,
   chain: cfPrimitivesChainsForeignChain,
   address: cfChainsAddressForeignChainAddress,
 });
+
+export const liquidityProviderLiquidityRefundAddressRegisteredEvent = defineEvent(
+  'LiquidityProvider.LiquidityRefundAddressRegistered',
+  liquidityProviderLiquidityRefundAddressRegistered,
+);

--- a/packages/processor/generated/220/liquidityProvider/withdrawalEgressScheduled.ts
+++ b/packages/processor/generated/220/liquidityProvider/withdrawalEgressScheduled.ts
@@ -5,6 +5,7 @@ import {
   cfPrimitivesChainsForeignChain,
   numberOrHex,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const liquidityProviderWithdrawalEgressScheduled = z.object({
   egressId: z.tuple([cfPrimitivesChainsForeignChain, numberOrHex]),
@@ -13,3 +14,8 @@ export const liquidityProviderWithdrawalEgressScheduled = z.object({
   destinationAddress: cfChainsAddressEncodedAddress,
   fee: numberOrHex,
 });
+
+export const liquidityProviderWithdrawalEgressScheduledEvent = defineEvent(
+  'LiquidityProvider.WithdrawalEgressScheduled',
+  liquidityProviderWithdrawalEgressScheduled,
+);

--- a/packages/processor/generated/220/polkadotBroadcaster/callResigned.ts
+++ b/packages/processor/generated/220/polkadotBroadcaster/callResigned.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { cfChainsDotPolkadotTransactionData } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const polkadotBroadcasterCallResigned = z.object({
   broadcastId: z.number(),
   transactionPayload: cfChainsDotPolkadotTransactionData,
 });
+
+export const polkadotBroadcasterCallResignedEvent = defineEvent(
+  'PolkadotBroadcaster.CallResigned',
+  polkadotBroadcasterCallResigned,
+);

--- a/packages/processor/generated/220/polkadotIngressEgress/batchBroadcastRequested.ts
+++ b/packages/processor/generated/220/polkadotIngressEgress/batchBroadcastRequested.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsForeignChain, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const polkadotIngressEgressBatchBroadcastRequested = z.object({
   broadcastId: z.number(),
   egressIds: z.array(z.tuple([cfPrimitivesChainsForeignChain, numberOrHex])),
 });
+
+export const polkadotIngressEgressBatchBroadcastRequestedEvent = defineEvent(
+  'PolkadotIngressEgress.BatchBroadcastRequested',
+  polkadotIngressEgressBatchBroadcastRequested,
+);

--- a/packages/processor/generated/220/polkadotIngressEgress/ccmBroadcastRequested.ts
+++ b/packages/processor/generated/220/polkadotIngressEgress/ccmBroadcastRequested.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsForeignChain, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const polkadotIngressEgressCcmBroadcastRequested = z.object({
   broadcastId: z.number(),
   egressId: z.tuple([cfPrimitivesChainsForeignChain, numberOrHex]),
 });
+
+export const polkadotIngressEgressCcmBroadcastRequestedEvent = defineEvent(
+  'PolkadotIngressEgress.CcmBroadcastRequested',
+  polkadotIngressEgressCcmBroadcastRequested,
+);

--- a/packages/processor/generated/220/polkadotIngressEgress/ccmEgressInvalid.ts
+++ b/packages/processor/generated/220/polkadotIngressEgress/ccmEgressInvalid.ts
@@ -4,8 +4,14 @@ import {
   cfPrimitivesChainsForeignChain,
   numberOrHex,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const polkadotIngressEgressCcmEgressInvalid = z.object({
   egressId: z.tuple([cfPrimitivesChainsForeignChain, numberOrHex]),
   error: cfChainsExecutexSwapAndCallError,
 });
+
+export const polkadotIngressEgressCcmEgressInvalidEvent = defineEvent(
+  'PolkadotIngressEgress.CcmEgressInvalid',
+  polkadotIngressEgressCcmEgressInvalid,
+);

--- a/packages/processor/generated/220/polkadotIngressEgress/depositBoosted.ts
+++ b/packages/processor/generated/220/polkadotIngressEgress/depositBoosted.ts
@@ -7,6 +7,7 @@ import {
   numberOrHex,
   palletCfPolkadotIngressEgressDepositAction,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const polkadotIngressEgressDepositBoosted = z.object({
   depositAddress: hexString.nullish(),
@@ -22,3 +23,8 @@ export const polkadotIngressEgressDepositBoosted = z.object({
   action: palletCfPolkadotIngressEgressDepositAction,
   originType: cfChainsDepositOriginType,
 });
+
+export const polkadotIngressEgressDepositBoostedEvent = defineEvent(
+  'PolkadotIngressEgress.DepositBoosted',
+  polkadotIngressEgressDepositBoosted,
+);

--- a/packages/processor/generated/220/polkadotIngressEgress/depositFailed.ts
+++ b/packages/processor/generated/220/polkadotIngressEgress/depositFailed.ts
@@ -3,9 +3,15 @@ import {
   palletCfPolkadotIngressEgressDepositFailedDetailsPolkadot,
   palletCfPolkadotIngressEgressDepositFailedReason,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const polkadotIngressEgressDepositFailed = z.object({
   blockHeight: z.number(),
   reason: palletCfPolkadotIngressEgressDepositFailedReason,
   details: palletCfPolkadotIngressEgressDepositFailedDetailsPolkadot,
 });
+
+export const polkadotIngressEgressDepositFailedEvent = defineEvent(
+  'PolkadotIngressEgress.DepositFailed',
+  polkadotIngressEgressDepositFailed,
+);

--- a/packages/processor/generated/220/polkadotIngressEgress/depositFinalised.ts
+++ b/packages/processor/generated/220/polkadotIngressEgress/depositFinalised.ts
@@ -6,6 +6,7 @@ import {
   numberOrHex,
   palletCfPolkadotIngressEgressDepositAction,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const polkadotIngressEgressDepositFinalised = z.object({
   depositAddress: hexString.nullish(),
@@ -19,3 +20,8 @@ export const polkadotIngressEgressDepositFinalised = z.object({
   channelId: numberOrHex.nullish(),
   originType: cfChainsDepositOriginType,
 });
+
+export const polkadotIngressEgressDepositFinalisedEvent = defineEvent(
+  'PolkadotIngressEgress.DepositFinalised',
+  polkadotIngressEgressDepositFinalised,
+);

--- a/packages/processor/generated/220/polkadotIngressEgress/transferFallbackRequested.ts
+++ b/packages/processor/generated/220/polkadotIngressEgress/transferFallbackRequested.ts
@@ -5,6 +5,7 @@ import {
   hexString,
   numberOrHex,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const polkadotIngressEgressTransferFallbackRequested = z.object({
   asset: cfPrimitivesChainsAssetsDotAsset,
@@ -13,3 +14,8 @@ export const polkadotIngressEgressTransferFallbackRequested = z.object({
   broadcastId: z.number(),
   egressDetails: cfTraitsScheduledEgressDetailsPolkadot.nullish(),
 });
+
+export const polkadotIngressEgressTransferFallbackRequestedEvent = defineEvent(
+  'PolkadotIngressEgress.TransferFallbackRequested',
+  polkadotIngressEgressTransferFallbackRequested,
+);

--- a/packages/processor/generated/220/reputation/offencePenalty.ts
+++ b/packages/processor/generated/220/reputation/offencePenalty.ts
@@ -1,8 +1,14 @@
 import { z } from 'zod';
 import { accountId, stateChainRuntimeChainflipOffencesOffence } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const reputationOffencePenalty = z.object({
   offender: accountId,
   offence: stateChainRuntimeChainflipOffencesOffence,
   penalty: z.number(),
 });
+
+export const reputationOffencePenaltyEvent = defineEvent(
+  'Reputation.OffencePenalty',
+  reputationOffencePenalty,
+);

--- a/packages/processor/generated/220/reputation/penaltyUpdated.ts
+++ b/packages/processor/generated/220/reputation/penaltyUpdated.ts
@@ -1,8 +1,14 @@
 import { z } from 'zod';
 import { palletCfReputationPenalty, stateChainRuntimeChainflipOffencesOffence } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const reputationPenaltyUpdated = z.object({
   offence: stateChainRuntimeChainflipOffencesOffence,
   oldPenalty: palletCfReputationPenalty,
   newPenalty: palletCfReputationPenalty,
 });
+
+export const reputationPenaltyUpdatedEvent = defineEvent(
+  'Reputation.PenaltyUpdated',
+  reputationPenaltyUpdated,
+);

--- a/packages/processor/generated/220/solanaBroadcaster/callResigned.ts
+++ b/packages/processor/generated/220/solanaBroadcaster/callResigned.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { cfChainsSolSolanaTransactionData } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const solanaBroadcasterCallResigned = z.object({
   broadcastId: z.number(),
   transactionPayload: cfChainsSolSolanaTransactionData,
 });
+
+export const solanaBroadcasterCallResignedEvent = defineEvent(
+  'SolanaBroadcaster.CallResigned',
+  solanaBroadcasterCallResigned,
+);

--- a/packages/processor/generated/220/solanaIngressEgress/batchBroadcastRequested.ts
+++ b/packages/processor/generated/220/solanaIngressEgress/batchBroadcastRequested.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsForeignChain, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const solanaIngressEgressBatchBroadcastRequested = z.object({
   broadcastId: z.number(),
   egressIds: z.array(z.tuple([cfPrimitivesChainsForeignChain, numberOrHex])),
 });
+
+export const solanaIngressEgressBatchBroadcastRequestedEvent = defineEvent(
+  'SolanaIngressEgress.BatchBroadcastRequested',
+  solanaIngressEgressBatchBroadcastRequested,
+);

--- a/packages/processor/generated/220/solanaIngressEgress/ccmBroadcastRequested.ts
+++ b/packages/processor/generated/220/solanaIngressEgress/ccmBroadcastRequested.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsForeignChain, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const solanaIngressEgressCcmBroadcastRequested = z.object({
   broadcastId: z.number(),
   egressId: z.tuple([cfPrimitivesChainsForeignChain, numberOrHex]),
 });
+
+export const solanaIngressEgressCcmBroadcastRequestedEvent = defineEvent(
+  'SolanaIngressEgress.CcmBroadcastRequested',
+  solanaIngressEgressCcmBroadcastRequested,
+);

--- a/packages/processor/generated/220/solanaIngressEgress/ccmEgressInvalid.ts
+++ b/packages/processor/generated/220/solanaIngressEgress/ccmEgressInvalid.ts
@@ -4,8 +4,14 @@ import {
   cfPrimitivesChainsForeignChain,
   numberOrHex,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const solanaIngressEgressCcmEgressInvalid = z.object({
   egressId: z.tuple([cfPrimitivesChainsForeignChain, numberOrHex]),
   error: cfChainsExecutexSwapAndCallError,
 });
+
+export const solanaIngressEgressCcmEgressInvalidEvent = defineEvent(
+  'SolanaIngressEgress.CcmEgressInvalid',
+  solanaIngressEgressCcmEgressInvalid,
+);

--- a/packages/processor/generated/220/solanaIngressEgress/depositBoosted.ts
+++ b/packages/processor/generated/220/solanaIngressEgress/depositBoosted.ts
@@ -8,6 +8,7 @@ import {
   numberOrHex,
   palletCfSolanaIngressEgressDepositAction,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const solanaIngressEgressDepositBoosted = z.object({
   depositAddress: hexString.nullish(),
@@ -23,3 +24,8 @@ export const solanaIngressEgressDepositBoosted = z.object({
   action: palletCfSolanaIngressEgressDepositAction,
   originType: cfChainsDepositOriginType,
 });
+
+export const solanaIngressEgressDepositBoostedEvent = defineEvent(
+  'SolanaIngressEgress.DepositBoosted',
+  solanaIngressEgressDepositBoosted,
+);

--- a/packages/processor/generated/220/solanaIngressEgress/depositFailed.ts
+++ b/packages/processor/generated/220/solanaIngressEgress/depositFailed.ts
@@ -4,9 +4,15 @@ import {
   palletCfSolanaIngressEgressDepositFailedDetailsSolana,
   palletCfSolanaIngressEgressDepositFailedReason,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const solanaIngressEgressDepositFailed = z.object({
   blockHeight: numberOrHex,
   reason: palletCfSolanaIngressEgressDepositFailedReason,
   details: palletCfSolanaIngressEgressDepositFailedDetailsSolana,
 });
+
+export const solanaIngressEgressDepositFailedEvent = defineEvent(
+  'SolanaIngressEgress.DepositFailed',
+  solanaIngressEgressDepositFailed,
+);

--- a/packages/processor/generated/220/solanaIngressEgress/depositFinalised.ts
+++ b/packages/processor/generated/220/solanaIngressEgress/depositFinalised.ts
@@ -7,6 +7,7 @@ import {
   numberOrHex,
   palletCfSolanaIngressEgressDepositAction,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const solanaIngressEgressDepositFinalised = z.object({
   depositAddress: hexString.nullish(),
@@ -20,3 +21,8 @@ export const solanaIngressEgressDepositFinalised = z.object({
   channelId: numberOrHex.nullish(),
   originType: cfChainsDepositOriginType,
 });
+
+export const solanaIngressEgressDepositFinalisedEvent = defineEvent(
+  'SolanaIngressEgress.DepositFinalised',
+  solanaIngressEgressDepositFinalised,
+);

--- a/packages/processor/generated/220/solanaIngressEgress/transferFallbackRequested.ts
+++ b/packages/processor/generated/220/solanaIngressEgress/transferFallbackRequested.ts
@@ -5,6 +5,7 @@ import {
   hexString,
   numberOrHex,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const solanaIngressEgressTransferFallbackRequested = z.object({
   asset: cfPrimitivesChainsAssetsSolAsset,
@@ -13,3 +14,8 @@ export const solanaIngressEgressTransferFallbackRequested = z.object({
   broadcastId: z.number(),
   egressDetails: cfTraitsScheduledEgressDetailsSolana.nullish(),
 });
+
+export const solanaIngressEgressTransferFallbackRequestedEvent = defineEvent(
+  'SolanaIngressEgress.TransferFallbackRequested',
+  solanaIngressEgressTransferFallbackRequested,
+);

--- a/packages/processor/generated/220/swapping/accountCreationDepositAddressReady.ts
+++ b/packages/processor/generated/220/swapping/accountCreationDepositAddressReady.ts
@@ -5,6 +5,7 @@ import {
   cfPrimitivesChainsAssetsAnyAsset,
   numberOrHex,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const swappingAccountCreationDepositAddressReady = z.object({
   channelId: numberOrHex,
@@ -17,3 +18,8 @@ export const swappingAccountCreationDepositAddressReady = z.object({
   channelOpeningFee: numberOrHex,
   refundAddress: cfChainsAddressEncodedAddress,
 });
+
+export const swappingAccountCreationDepositAddressReadyEvent = defineEvent(
+  'Swapping.AccountCreationDepositAddressReady',
+  swappingAccountCreationDepositAddressReady,
+);

--- a/packages/processor/generated/220/swapping/affiliateDeregistration.ts
+++ b/packages/processor/generated/220/swapping/affiliateDeregistration.ts
@@ -1,8 +1,14 @@
 import { z } from 'zod';
 import { accountId } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const swappingAffiliateDeregistration = z.object({
   brokerId: accountId,
   shortId: z.number(),
   affiliateAccountId: accountId,
 });
+
+export const swappingAffiliateDeregistrationEvent = defineEvent(
+  'Swapping.AffiliateDeregistration',
+  swappingAffiliateDeregistration,
+);

--- a/packages/processor/generated/220/swapping/batchSwapFailed.ts
+++ b/packages/processor/generated/220/swapping/batchSwapFailed.ts
@@ -1,8 +1,14 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsAssetsAnyAsset, cfPrimitivesSwapLeg, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const swappingBatchSwapFailed = z.object({
   asset: cfPrimitivesChainsAssetsAnyAsset,
   direction: cfPrimitivesSwapLeg,
   amount: numberOrHex,
 });
+
+export const swappingBatchSwapFailedEvent = defineEvent(
+  'Swapping.BatchSwapFailed',
+  swappingBatchSwapFailed,
+);

--- a/packages/processor/generated/220/swapping/creditedOnChain.ts
+++ b/packages/processor/generated/220/swapping/creditedOnChain.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { accountId, cfPrimitivesChainsAssetsAnyAsset, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const swappingCreditedOnChain = z.object({
   swapRequestId: numberOrHex,
@@ -7,3 +8,8 @@ export const swappingCreditedOnChain = z.object({
   asset: cfPrimitivesChainsAssetsAnyAsset,
   amount: numberOrHex,
 });
+
+export const swappingCreditedOnChainEvent = defineEvent(
+  'Swapping.CreditedOnChain',
+  swappingCreditedOnChain,
+);

--- a/packages/processor/generated/220/swapping/palletConfigUpdated.ts
+++ b/packages/processor/generated/220/swapping/palletConfigUpdated.ts
@@ -1,4 +1,10 @@
 import { z } from 'zod';
 import { palletCfSwappingPalletConfigUpdate } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const swappingPalletConfigUpdated = z.object({ update: palletCfSwappingPalletConfigUpdate });
+
+export const swappingPalletConfigUpdatedEvent = defineEvent(
+  'Swapping.PalletConfigUpdated',
+  swappingPalletConfigUpdated,
+);

--- a/packages/processor/generated/220/swapping/refundEgressIgnored.ts
+++ b/packages/processor/generated/220/swapping/refundEgressIgnored.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsAssetsAnyAsset, numberOrHex, spRuntimeDispatchError } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const swappingRefundEgressIgnored = z.object({
   swapRequestId: numberOrHex,
@@ -7,3 +8,8 @@ export const swappingRefundEgressIgnored = z.object({
   amount: numberOrHex,
   reason: spRuntimeDispatchError,
 });
+
+export const swappingRefundEgressIgnoredEvent = defineEvent(
+  'Swapping.RefundEgressIgnored',
+  swappingRefundEgressIgnored,
+);

--- a/packages/processor/generated/220/swapping/refundEgressScheduled.ts
+++ b/packages/processor/generated/220/swapping/refundEgressScheduled.ts
@@ -4,6 +4,7 @@ import {
   cfPrimitivesChainsForeignChain,
   numberOrHex,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const swappingRefundEgressScheduled = z.object({
   swapRequestId: numberOrHex,
@@ -13,3 +14,8 @@ export const swappingRefundEgressScheduled = z.object({
   egressFee: z.tuple([numberOrHex, cfPrimitivesChainsAssetsAnyAsset]),
   refundFee: numberOrHex,
 });
+
+export const swappingRefundEgressScheduledEvent = defineEvent(
+  'Swapping.RefundEgressScheduled',
+  swappingRefundEgressScheduled,
+);

--- a/packages/processor/generated/220/swapping/refundedOnChain.ts
+++ b/packages/processor/generated/220/swapping/refundedOnChain.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { accountId, cfPrimitivesChainsAssetsAnyAsset, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const swappingRefundedOnChain = z.object({
   swapRequestId: numberOrHex,
@@ -8,3 +9,8 @@ export const swappingRefundedOnChain = z.object({
   amount: numberOrHex,
   refundFee: numberOrHex,
 });
+
+export const swappingRefundedOnChainEvent = defineEvent(
+  'Swapping.RefundedOnChain',
+  swappingRefundedOnChain,
+);

--- a/packages/processor/generated/220/swapping/swapAmountConfiscated.ts
+++ b/packages/processor/generated/220/swapping/swapAmountConfiscated.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsAssetsAnyAsset, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const swappingSwapAmountConfiscated = z.object({
   swapRequestId: numberOrHex,
@@ -7,3 +8,8 @@ export const swappingSwapAmountConfiscated = z.object({
   totalAmount: numberOrHex,
   confiscatedAmount: numberOrHex,
 });
+
+export const swappingSwapAmountConfiscatedEvent = defineEvent(
+  'Swapping.SwapAmountConfiscated',
+  swappingSwapAmountConfiscated,
+);

--- a/packages/processor/generated/220/swapping/swapDepositAddressReady.ts
+++ b/packages/processor/generated/220/swapping/swapDepositAddressReady.ts
@@ -9,6 +9,7 @@ import {
   cfPrimitivesDcaParameters,
   numberOrHex,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const swappingSwapDepositAddressReady = z.object({
   depositAddress: cfChainsAddressEncodedAddress,
@@ -26,3 +27,8 @@ export const swappingSwapDepositAddressReady = z.object({
   refundParameters: cfChainsRefundParametersChannelRefundParameters,
   dcaParameters: cfPrimitivesDcaParameters.nullish(),
 });
+
+export const swappingSwapDepositAddressReadyEvent = defineEvent(
+  'Swapping.SwapDepositAddressReady',
+  swappingSwapDepositAddressReady,
+);

--- a/packages/processor/generated/220/swapping/swapEgressIgnored.ts
+++ b/packages/processor/generated/220/swapping/swapEgressIgnored.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsAssetsAnyAsset, numberOrHex, spRuntimeDispatchError } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const swappingSwapEgressIgnored = z.object({
   swapRequestId: numberOrHex,
@@ -7,3 +8,8 @@ export const swappingSwapEgressIgnored = z.object({
   amount: numberOrHex,
   reason: spRuntimeDispatchError,
 });
+
+export const swappingSwapEgressIgnoredEvent = defineEvent(
+  'Swapping.SwapEgressIgnored',
+  swappingSwapEgressIgnored,
+);

--- a/packages/processor/generated/220/swapping/swapEgressScheduled.ts
+++ b/packages/processor/generated/220/swapping/swapEgressScheduled.ts
@@ -4,6 +4,7 @@ import {
   cfPrimitivesChainsForeignChain,
   numberOrHex,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const swappingSwapEgressScheduled = z.object({
   swapRequestId: numberOrHex,
@@ -12,3 +13,8 @@ export const swappingSwapEgressScheduled = z.object({
   amount: numberOrHex,
   egressFee: z.tuple([numberOrHex, cfPrimitivesChainsAssetsAnyAsset]),
 });
+
+export const swappingSwapEgressScheduledEvent = defineEvent(
+  'Swapping.SwapEgressScheduled',
+  swappingSwapEgressScheduled,
+);

--- a/packages/processor/generated/220/swapping/swapExecuted.ts
+++ b/packages/processor/generated/220/swapping/swapExecuted.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsAssetsAnyAsset, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const swappingSwapExecuted = z.object({
   swapRequestId: numberOrHex,
@@ -14,3 +15,5 @@ export const swappingSwapExecuted = z.object({
   oracleDelta: z.number().nullish(),
   oracleDeltaExFees: z.number().nullish(),
 });
+
+export const swappingSwapExecutedEvent = defineEvent('Swapping.SwapExecuted', swappingSwapExecuted);

--- a/packages/processor/generated/220/swapping/swapRequested.ts
+++ b/packages/processor/generated/220/swapping/swapRequested.ts
@@ -8,6 +8,7 @@ import {
   cfTraitsSwappingSwapRequestTypeGeneric,
   numberOrHex,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const swappingSwapRequested = z.object({
   swapRequestId: numberOrHex,
@@ -20,3 +21,8 @@ export const swappingSwapRequested = z.object({
   priceLimitsAndExpiry: cfTraitsSwappingPriceLimitsAndExpiry.nullish(),
   dcaParameters: cfPrimitivesDcaParameters.nullish(),
 });
+
+export const swappingSwapRequestedEvent = defineEvent(
+  'Swapping.SwapRequested',
+  swappingSwapRequested,
+);

--- a/packages/processor/generated/220/swapping/withdrawalRequested.ts
+++ b/packages/processor/generated/220/swapping/withdrawalRequested.ts
@@ -6,6 +6,7 @@ import {
   cfPrimitivesChainsForeignChain,
   numberOrHex,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const swappingWithdrawalRequested = z.object({
   accountId,
@@ -15,3 +16,8 @@ export const swappingWithdrawalRequested = z.object({
   egressFee: numberOrHex,
   destinationAddress: cfChainsAddressEncodedAddress,
 });
+
+export const swappingWithdrawalRequestedEvent = defineEvent(
+  'Swapping.WithdrawalRequested',
+  swappingWithdrawalRequested,
+);

--- a/packages/processor/generated/220/tokenholderGovernance/govKeyUpdatedHasFailed.ts
+++ b/packages/processor/generated/220/tokenholderGovernance/govKeyUpdatedHasFailed.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsForeignChain, hexString } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tokenholderGovernanceGovKeyUpdatedHasFailed = z.object({
   chain: cfPrimitivesChainsForeignChain,
   key: hexString,
 });
+
+export const tokenholderGovernanceGovKeyUpdatedHasFailedEvent = defineEvent(
+  'TokenholderGovernance.GovKeyUpdatedHasFailed',
+  tokenholderGovernanceGovKeyUpdatedHasFailed,
+);

--- a/packages/processor/generated/220/tokenholderGovernance/govKeyUpdatedWasSuccessful.ts
+++ b/packages/processor/generated/220/tokenholderGovernance/govKeyUpdatedWasSuccessful.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsForeignChain, hexString } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tokenholderGovernanceGovKeyUpdatedWasSuccessful = z.object({
   chain: cfPrimitivesChainsForeignChain,
   key: hexString,
 });
+
+export const tokenholderGovernanceGovKeyUpdatedWasSuccessfulEvent = defineEvent(
+  'TokenholderGovernance.GovKeyUpdatedWasSuccessful',
+  tokenholderGovernanceGovKeyUpdatedWasSuccessful,
+);

--- a/packages/processor/generated/220/tokenholderGovernance/proposalEnacted.ts
+++ b/packages/processor/generated/220/tokenholderGovernance/proposalEnacted.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 import { palletCfTokenholderGovernanceProposal } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tokenholderGovernanceProposalEnacted = z.object({
   proposal: palletCfTokenholderGovernanceProposal,
 });
+
+export const tokenholderGovernanceProposalEnactedEvent = defineEvent(
+  'TokenholderGovernance.ProposalEnacted',
+  tokenholderGovernanceProposalEnacted,
+);

--- a/packages/processor/generated/220/tokenholderGovernance/proposalPassed.ts
+++ b/packages/processor/generated/220/tokenholderGovernance/proposalPassed.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 import { palletCfTokenholderGovernanceProposal } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tokenholderGovernanceProposalPassed = z.object({
   proposal: palletCfTokenholderGovernanceProposal,
 });
+
+export const tokenholderGovernanceProposalPassedEvent = defineEvent(
+  'TokenholderGovernance.ProposalPassed',
+  tokenholderGovernanceProposalPassed,
+);

--- a/packages/processor/generated/220/tokenholderGovernance/proposalRejected.ts
+++ b/packages/processor/generated/220/tokenholderGovernance/proposalRejected.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 import { palletCfTokenholderGovernanceProposal } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tokenholderGovernanceProposalRejected = z.object({
   proposal: palletCfTokenholderGovernanceProposal,
 });
+
+export const tokenholderGovernanceProposalRejectedEvent = defineEvent(
+  'TokenholderGovernance.ProposalRejected',
+  tokenholderGovernanceProposalRejected,
+);

--- a/packages/processor/generated/220/tokenholderGovernance/proposalSubmitted.ts
+++ b/packages/processor/generated/220/tokenholderGovernance/proposalSubmitted.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 import { palletCfTokenholderGovernanceProposal } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tokenholderGovernanceProposalSubmitted = z.object({
   proposal: palletCfTokenholderGovernanceProposal,
 });
+
+export const tokenholderGovernanceProposalSubmittedEvent = defineEvent(
+  'TokenholderGovernance.ProposalSubmitted',
+  tokenholderGovernanceProposalSubmitted,
+);

--- a/packages/processor/generated/220/tradingStrategy/fundsAddedToStrategy.ts
+++ b/packages/processor/generated/220/tradingStrategy/fundsAddedToStrategy.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { accountId, cfPrimitivesChainsAssetsAnyAsset, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tradingStrategyFundsAddedToStrategy = z.object({
   strategyId: accountId,
   amounts: z.array(z.tuple([cfPrimitivesChainsAssetsAnyAsset, numberOrHex])),
 });
+
+export const tradingStrategyFundsAddedToStrategyEvent = defineEvent(
+  'TradingStrategy.FundsAddedToStrategy',
+  tradingStrategyFundsAddedToStrategy,
+);

--- a/packages/processor/generated/220/tradingStrategy/palletConfigUpdated.ts
+++ b/packages/processor/generated/220/tradingStrategy/palletConfigUpdated.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 import { palletCfTradingStrategyPalletConfigUpdate } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tradingStrategyPalletConfigUpdated = z.object({
   update: palletCfTradingStrategyPalletConfigUpdate,
 });
+
+export const tradingStrategyPalletConfigUpdatedEvent = defineEvent(
+  'TradingStrategy.PalletConfigUpdated',
+  tradingStrategyPalletConfigUpdated,
+);

--- a/packages/processor/generated/220/tradingStrategy/strategyDeployed.ts
+++ b/packages/processor/generated/220/tradingStrategy/strategyDeployed.ts
@@ -1,8 +1,14 @@
 import { z } from 'zod';
 import { accountId, palletCfTradingStrategyTradingStrategy } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tradingStrategyStrategyDeployed = z.object({
   accountId,
   strategyId: accountId,
   strategy: palletCfTradingStrategyTradingStrategy,
 });
+
+export const tradingStrategyStrategyDeployedEvent = defineEvent(
+  'TradingStrategy.StrategyDeployed',
+  tradingStrategyStrategyDeployed,
+);

--- a/packages/processor/generated/220/tronBroadcaster/broadcastAborted.ts
+++ b/packages/processor/generated/220/tronBroadcaster/broadcastAborted.ts
@@ -1,3 +1,9 @@
 import { z } from 'zod';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronBroadcasterBroadcastAborted = z.object({ broadcastId: z.number() });
+
+export const tronBroadcasterBroadcastAbortedEvent = defineEvent(
+  'TronBroadcaster.BroadcastAborted',
+  tronBroadcasterBroadcastAborted,
+);

--- a/packages/processor/generated/220/tronBroadcaster/broadcastRetryScheduled.ts
+++ b/packages/processor/generated/220/tronBroadcaster/broadcastRetryScheduled.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronBroadcasterBroadcastRetryScheduled = z.object({
   broadcastId: z.number(),
   retryBlock: z.number(),
 });
+
+export const tronBroadcasterBroadcastRetryScheduledEvent = defineEvent(
+  'TronBroadcaster.BroadcastRetryScheduled',
+  tronBroadcasterBroadcastRetryScheduled,
+);

--- a/packages/processor/generated/220/tronBroadcaster/broadcastSuccess.ts
+++ b/packages/processor/generated/220/tronBroadcaster/broadcastSuccess.ts
@@ -1,8 +1,14 @@
 import { z } from 'zod';
 import { cfChainsEvmSchnorrVerificationComponents, hexString } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronBroadcasterBroadcastSuccess = z.object({
   broadcastId: z.number(),
   transactionOutId: cfChainsEvmSchnorrVerificationComponents,
   transactionRef: hexString,
 });
+
+export const tronBroadcasterBroadcastSuccessEvent = defineEvent(
+  'TronBroadcaster.BroadcastSuccess',
+  tronBroadcasterBroadcastSuccess,
+);

--- a/packages/processor/generated/220/tronBroadcaster/broadcastTimeout.ts
+++ b/packages/processor/generated/220/tronBroadcaster/broadcastTimeout.ts
@@ -1,3 +1,9 @@
 import { z } from 'zod';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronBroadcasterBroadcastTimeout = z.object({ broadcastId: z.number() });
+
+export const tronBroadcasterBroadcastTimeoutEvent = defineEvent(
+  'TronBroadcaster.BroadcastTimeout',
+  tronBroadcasterBroadcastTimeout,
+);

--- a/packages/processor/generated/220/tronBroadcaster/callResigned.ts
+++ b/packages/processor/generated/220/tronBroadcaster/callResigned.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { cfChainsTronTronTransaction } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronBroadcasterCallResigned = z.object({
   broadcastId: z.number(),
   transactionPayload: cfChainsTronTronTransaction,
 });
+
+export const tronBroadcasterCallResignedEvent = defineEvent(
+  'TronBroadcaster.CallResigned',
+  tronBroadcasterCallResigned,
+);

--- a/packages/processor/generated/220/tronBroadcaster/historicalBroadcastRequested.ts
+++ b/packages/processor/generated/220/tronBroadcaster/historicalBroadcastRequested.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronBroadcasterHistoricalBroadcastRequested = z.object({
   broadcastId: z.number(),
   thresholdSignatureRequestId: z.number(),
   epochIndex: z.number(),
 });
+
+export const tronBroadcasterHistoricalBroadcastRequestedEvent = defineEvent(
+  'TronBroadcaster.HistoricalBroadcastRequested',
+  tronBroadcasterHistoricalBroadcastRequested,
+);

--- a/packages/processor/generated/220/tronBroadcaster/palletConfigUpdated.ts
+++ b/packages/processor/generated/220/tronBroadcaster/palletConfigUpdated.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 import { palletCfBroadcastPalletConfigUpdate } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronBroadcasterPalletConfigUpdated = z.object({
   update: palletCfBroadcastPalletConfigUpdate,
 });
+
+export const tronBroadcasterPalletConfigUpdatedEvent = defineEvent(
+  'TronBroadcaster.PalletConfigUpdated',
+  tronBroadcasterPalletConfigUpdated,
+);

--- a/packages/processor/generated/220/tronBroadcaster/thresholdSignatureInvalid.ts
+++ b/packages/processor/generated/220/tronBroadcaster/thresholdSignatureInvalid.ts
@@ -1,3 +1,9 @@
 import { z } from 'zod';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronBroadcasterThresholdSignatureInvalid = z.object({ broadcastId: z.number() });
+
+export const tronBroadcasterThresholdSignatureInvalidEvent = defineEvent(
+  'TronBroadcaster.ThresholdSignatureInvalid',
+  tronBroadcasterThresholdSignatureInvalid,
+);

--- a/packages/processor/generated/220/tronBroadcaster/transactionBroadcastRequest.ts
+++ b/packages/processor/generated/220/tronBroadcaster/transactionBroadcastRequest.ts
@@ -4,6 +4,7 @@ import {
   cfChainsEvmSchnorrVerificationComponents,
   cfChainsTronTronTransaction,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronBroadcasterTransactionBroadcastRequest = z.object({
   broadcastId: z.number(),
@@ -11,3 +12,8 @@ export const tronBroadcasterTransactionBroadcastRequest = z.object({
   transactionPayload: cfChainsTronTronTransaction,
   transactionOutId: cfChainsEvmSchnorrVerificationComponents,
 });
+
+export const tronBroadcasterTransactionBroadcastRequestEvent = defineEvent(
+  'TronBroadcaster.TransactionBroadcastRequest',
+  tronBroadcasterTransactionBroadcastRequest,
+);

--- a/packages/processor/generated/220/tronBroadcaster/transactionFeeDeficitRecorded.ts
+++ b/packages/processor/generated/220/tronBroadcaster/transactionFeeDeficitRecorded.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { hexString, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronBroadcasterTransactionFeeDeficitRecorded = z.object({
   beneficiary: hexString,
   amount: numberOrHex,
 });
+
+export const tronBroadcasterTransactionFeeDeficitRecordedEvent = defineEvent(
+  'TronBroadcaster.TransactionFeeDeficitRecorded',
+  tronBroadcasterTransactionFeeDeficitRecorded,
+);

--- a/packages/processor/generated/220/tronBroadcaster/transactionFeeDeficitRefused.ts
+++ b/packages/processor/generated/220/tronBroadcaster/transactionFeeDeficitRefused.ts
@@ -1,4 +1,10 @@
 import { z } from 'zod';
 import { hexString } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronBroadcasterTransactionFeeDeficitRefused = z.object({ beneficiary: hexString });
+
+export const tronBroadcasterTransactionFeeDeficitRefusedEvent = defineEvent(
+  'TronBroadcaster.TransactionFeeDeficitRefused',
+  tronBroadcasterTransactionFeeDeficitRefused,
+);

--- a/packages/processor/generated/220/tronChainTracking/chainStateUpdated.ts
+++ b/packages/processor/generated/220/tronChainTracking/chainStateUpdated.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 import { cfChainsChainStateTron } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronChainTrackingChainStateUpdated = z.object({
   newChainState: cfChainsChainStateTron,
 });
+
+export const tronChainTrackingChainStateUpdatedEvent = defineEvent(
+  'TronChainTracking.ChainStateUpdated',
+  tronChainTrackingChainStateUpdated,
+);

--- a/packages/processor/generated/220/tronChainTracking/feeMultiplierUpdated.ts
+++ b/packages/processor/generated/220/tronChainTracking/feeMultiplierUpdated.ts
@@ -1,4 +1,10 @@
 import { z } from 'zod';
 import { numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronChainTrackingFeeMultiplierUpdated = z.object({ newFeeMultiplier: numberOrHex });
+
+export const tronChainTrackingFeeMultiplierUpdatedEvent = defineEvent(
+  'TronChainTracking.FeeMultiplierUpdated',
+  tronChainTrackingFeeMultiplierUpdated,
+);

--- a/packages/processor/generated/220/tronElections/allVotesCleared.ts
+++ b/packages/processor/generated/220/tronElections/allVotesCleared.ts
@@ -1,3 +1,9 @@
 import { z } from 'zod';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronElectionsAllVotesCleared = z.null();
+
+export const tronElectionsAllVotesClearedEvent = defineEvent(
+  'TronElections.AllVotesCleared',
+  tronElectionsAllVotesCleared,
+);

--- a/packages/processor/generated/220/tronElections/allVotesNotCleared.ts
+++ b/packages/processor/generated/220/tronElections/allVotesNotCleared.ts
@@ -1,3 +1,9 @@
 import { z } from 'zod';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronElectionsAllVotesNotCleared = z.null();
+
+export const tronElectionsAllVotesNotClearedEvent = defineEvent(
+  'TronElections.AllVotesNotCleared',
+  tronElectionsAllVotesNotCleared,
+);

--- a/packages/processor/generated/220/tronElections/corruptStorage.ts
+++ b/packages/processor/generated/220/tronElections/corruptStorage.ts
@@ -1,3 +1,9 @@
 import { z } from 'zod';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronElectionsCorruptStorage = z.null();
+
+export const tronElectionsCorruptStorageEvent = defineEvent(
+  'TronElections.CorruptStorage',
+  tronElectionsCorruptStorage,
+);

--- a/packages/processor/generated/220/tronElections/electoralEvent.ts
+++ b/packages/processor/generated/220/tronElections/electoralEvent.ts
@@ -1,5 +1,11 @@
 import { z } from 'zod';
 import { stateChainRuntimeChainflipWitnessingTronElectionsTronElectoralEvents } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronElectionsElectoralEvent =
   stateChainRuntimeChainflipWitnessingTronElectionsTronElectoralEvents;
+
+export const tronElectionsElectoralEventEvent = defineEvent(
+  'TronElections.ElectoralEvent',
+  tronElectionsElectoralEvent,
+);

--- a/packages/processor/generated/220/tronElections/uninitialized.ts
+++ b/packages/processor/generated/220/tronElections/uninitialized.ts
@@ -1,3 +1,9 @@
 import { z } from 'zod';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronElectionsUninitialized = z.null();
+
+export const tronElectionsUninitializedEvent = defineEvent(
+  'TronElections.Uninitialized',
+  tronElectionsUninitialized,
+);

--- a/packages/processor/generated/220/tronElections/unknownElection.ts
+++ b/packages/processor/generated/220/tronElections/unknownElection.ts
@@ -3,8 +3,14 @@ import {
   numberOrHex,
   palletCfElectionsElectoralSystemsCompositeTuple5ImplsCompositeElectionIdentifierExtra,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronElectionsUnknownElection = z.tuple([
   numberOrHex,
   palletCfElectionsElectoralSystemsCompositeTuple5ImplsCompositeElectionIdentifierExtra,
 ]);
+
+export const tronElectionsUnknownElectionEvent = defineEvent(
+  'TronElections.UnknownElection',
+  tronElectionsUnknownElection,
+);

--- a/packages/processor/generated/220/tronIngressEgress/assetEgressStatusChanged.ts
+++ b/packages/processor/generated/220/tronIngressEgress/assetEgressStatusChanged.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsAssetsTronAsset } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronIngressEgressAssetEgressStatusChanged = z.object({
   asset: cfPrimitivesChainsAssetsTronAsset,
   disabled: z.boolean(),
 });
+
+export const tronIngressEgressAssetEgressStatusChangedEvent = defineEvent(
+  'TronIngressEgress.AssetEgressStatusChanged',
+  tronIngressEgressAssetEgressStatusChanged,
+);

--- a/packages/processor/generated/220/tronIngressEgress/batchBroadcastRequested.ts
+++ b/packages/processor/generated/220/tronIngressEgress/batchBroadcastRequested.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsForeignChain, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronIngressEgressBatchBroadcastRequested = z.object({
   broadcastId: z.number(),
   egressIds: z.array(z.tuple([cfPrimitivesChainsForeignChain, numberOrHex])),
 });
+
+export const tronIngressEgressBatchBroadcastRequestedEvent = defineEvent(
+  'TronIngressEgress.BatchBroadcastRequested',
+  tronIngressEgressBatchBroadcastRequested,
+);

--- a/packages/processor/generated/220/tronIngressEgress/boostedDepositLost.ts
+++ b/packages/processor/generated/220/tronIngressEgress/boostedDepositLost.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronIngressEgressBoostedDepositLost = z.object({
   prewitnessedDepositId: numberOrHex,
   amount: numberOrHex,
 });
+
+export const tronIngressEgressBoostedDepositLostEvent = defineEvent(
+  'TronIngressEgress.BoostedDepositLost',
+  tronIngressEgressBoostedDepositLost,
+);

--- a/packages/processor/generated/220/tronIngressEgress/ccmBroadcastFailed.ts
+++ b/packages/processor/generated/220/tronIngressEgress/ccmBroadcastFailed.ts
@@ -1,3 +1,9 @@
 import { z } from 'zod';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronIngressEgressCcmBroadcastFailed = z.object({ broadcastId: z.number() });
+
+export const tronIngressEgressCcmBroadcastFailedEvent = defineEvent(
+  'TronIngressEgress.CcmBroadcastFailed',
+  tronIngressEgressCcmBroadcastFailed,
+);

--- a/packages/processor/generated/220/tronIngressEgress/ccmBroadcastRequested.ts
+++ b/packages/processor/generated/220/tronIngressEgress/ccmBroadcastRequested.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsForeignChain, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronIngressEgressCcmBroadcastRequested = z.object({
   broadcastId: z.number(),
   egressId: z.tuple([cfPrimitivesChainsForeignChain, numberOrHex]),
 });
+
+export const tronIngressEgressCcmBroadcastRequestedEvent = defineEvent(
+  'TronIngressEgress.CcmBroadcastRequested',
+  tronIngressEgressCcmBroadcastRequested,
+);

--- a/packages/processor/generated/220/tronIngressEgress/ccmEgressInvalid.ts
+++ b/packages/processor/generated/220/tronIngressEgress/ccmEgressInvalid.ts
@@ -4,8 +4,14 @@ import {
   cfPrimitivesChainsForeignChain,
   numberOrHex,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronIngressEgressCcmEgressInvalid = z.object({
   egressId: z.tuple([cfPrimitivesChainsForeignChain, numberOrHex]),
   error: cfChainsExecutexSwapAndCallError,
 });
+
+export const tronIngressEgressCcmEgressInvalidEvent = defineEvent(
+  'TronIngressEgress.CcmEgressInvalid',
+  tronIngressEgressCcmEgressInvalid,
+);

--- a/packages/processor/generated/220/tronIngressEgress/channelOpeningFeePaid.ts
+++ b/packages/processor/generated/220/tronIngressEgress/channelOpeningFeePaid.ts
@@ -1,4 +1,10 @@
 import { z } from 'zod';
 import { numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronIngressEgressChannelOpeningFeePaid = z.object({ fee: numberOrHex });
+
+export const tronIngressEgressChannelOpeningFeePaidEvent = defineEvent(
+  'TronIngressEgress.ChannelOpeningFeePaid',
+  tronIngressEgressChannelOpeningFeePaid,
+);

--- a/packages/processor/generated/220/tronIngressEgress/channelRejectionRequestReceived.ts
+++ b/packages/processor/generated/220/tronIngressEgress/channelRejectionRequestReceived.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { accountId, hexString } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronIngressEgressChannelRejectionRequestReceived = z.object({
   accountId,
   depositAddress: hexString,
 });
+
+export const tronIngressEgressChannelRejectionRequestReceivedEvent = defineEvent(
+  'TronIngressEgress.ChannelRejectionRequestReceived',
+  tronIngressEgressChannelRejectionRequestReceived,
+);

--- a/packages/processor/generated/220/tronIngressEgress/depositBoosted.ts
+++ b/packages/processor/generated/220/tronIngressEgress/depositBoosted.ts
@@ -8,6 +8,7 @@ import {
   numberOrHex,
   palletCfTronIngressEgressDepositAction,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronIngressEgressDepositBoosted = z.object({
   depositAddress: hexString.nullish(),
@@ -23,3 +24,8 @@ export const tronIngressEgressDepositBoosted = z.object({
   action: palletCfTronIngressEgressDepositAction,
   originType: cfChainsDepositOriginType,
 });
+
+export const tronIngressEgressDepositBoostedEvent = defineEvent(
+  'TronIngressEgress.DepositBoosted',
+  tronIngressEgressDepositBoosted,
+);

--- a/packages/processor/generated/220/tronIngressEgress/depositFailed.ts
+++ b/packages/processor/generated/220/tronIngressEgress/depositFailed.ts
@@ -4,9 +4,15 @@ import {
   palletCfTronIngressEgressDepositFailedDetailsTron,
   palletCfTronIngressEgressDepositFailedReason,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronIngressEgressDepositFailed = z.object({
   blockHeight: numberOrHex,
   reason: palletCfTronIngressEgressDepositFailedReason,
   details: palletCfTronIngressEgressDepositFailedDetailsTron,
 });
+
+export const tronIngressEgressDepositFailedEvent = defineEvent(
+  'TronIngressEgress.DepositFailed',
+  tronIngressEgressDepositFailed,
+);

--- a/packages/processor/generated/220/tronIngressEgress/depositFetchesScheduled.ts
+++ b/packages/processor/generated/220/tronIngressEgress/depositFetchesScheduled.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsAssetsTronAsset, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronIngressEgressDepositFetchesScheduled = z.object({
   channelId: numberOrHex,
   asset: cfPrimitivesChainsAssetsTronAsset,
 });
+
+export const tronIngressEgressDepositFetchesScheduledEvent = defineEvent(
+  'TronIngressEgress.DepositFetchesScheduled',
+  tronIngressEgressDepositFetchesScheduled,
+);

--- a/packages/processor/generated/220/tronIngressEgress/depositFinalised.ts
+++ b/packages/processor/generated/220/tronIngressEgress/depositFinalised.ts
@@ -7,6 +7,7 @@ import {
   numberOrHex,
   palletCfTronIngressEgressDepositAction,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronIngressEgressDepositFinalised = z.object({
   depositAddress: hexString.nullish(),
@@ -20,3 +21,8 @@ export const tronIngressEgressDepositFinalised = z.object({
   channelId: numberOrHex.nullish(),
   originType: cfChainsDepositOriginType,
 });
+
+export const tronIngressEgressDepositFinalisedEvent = defineEvent(
+  'TronIngressEgress.DepositFinalised',
+  tronIngressEgressDepositFinalised,
+);

--- a/packages/processor/generated/220/tronIngressEgress/failedForeignChainCallExpired.ts
+++ b/packages/processor/generated/220/tronIngressEgress/failedForeignChainCallExpired.ts
@@ -1,3 +1,9 @@
 import { z } from 'zod';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronIngressEgressFailedForeignChainCallExpired = z.object({ broadcastId: z.number() });
+
+export const tronIngressEgressFailedForeignChainCallExpiredEvent = defineEvent(
+  'TronIngressEgress.FailedForeignChainCallExpired',
+  tronIngressEgressFailedForeignChainCallExpired,
+);

--- a/packages/processor/generated/220/tronIngressEgress/failedForeignChainCallResigned.ts
+++ b/packages/processor/generated/220/tronIngressEgress/failedForeignChainCallResigned.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronIngressEgressFailedForeignChainCallResigned = z.object({
   broadcastId: z.number(),
   thresholdSignatureId: z.number(),
 });
+
+export const tronIngressEgressFailedForeignChainCallResignedEvent = defineEvent(
+  'TronIngressEgress.FailedForeignChainCallResigned',
+  tronIngressEgressFailedForeignChainCallResigned,
+);

--- a/packages/processor/generated/220/tronIngressEgress/failedToBuildAllBatchCall.ts
+++ b/packages/processor/generated/220/tronIngressEgress/failedToBuildAllBatchCall.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 import { cfChainsAllBatchError } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronIngressEgressFailedToBuildAllBatchCall = z.object({
   error: cfChainsAllBatchError,
 });
+
+export const tronIngressEgressFailedToBuildAllBatchCallEvent = defineEvent(
+  'TronIngressEgress.FailedToBuildAllBatchCall',
+  tronIngressEgressFailedToBuildAllBatchCall,
+);

--- a/packages/processor/generated/220/tronIngressEgress/insufficientBoostLiquidity.ts
+++ b/packages/processor/generated/220/tronIngressEgress/insufficientBoostLiquidity.ts
@@ -4,6 +4,7 @@ import {
   cfPrimitivesChainsAssetsTronAsset,
   numberOrHex,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronIngressEgressInsufficientBoostLiquidity = z.object({
   prewitnessedDepositId: numberOrHex,
@@ -12,3 +13,8 @@ export const tronIngressEgressInsufficientBoostLiquidity = z.object({
   channelId: numberOrHex.nullish(),
   originType: cfChainsDepositOriginType,
 });
+
+export const tronIngressEgressInsufficientBoostLiquidityEvent = defineEvent(
+  'TronIngressEgress.InsufficientBoostLiquidity',
+  tronIngressEgressInsufficientBoostLiquidity,
+);

--- a/packages/processor/generated/220/tronIngressEgress/invalidCcmRefunded.ts
+++ b/packages/processor/generated/220/tronIngressEgress/invalidCcmRefunded.ts
@@ -1,8 +1,14 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsAssetsTronAsset, hexString, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronIngressEgressInvalidCcmRefunded = z.object({
   asset: cfPrimitivesChainsAssetsTronAsset,
   amount: numberOrHex,
   destinationAddress: hexString,
 });
+
+export const tronIngressEgressInvalidCcmRefundedEvent = defineEvent(
+  'TronIngressEgress.InvalidCcmRefunded',
+  tronIngressEgressInvalidCcmRefunded,
+);

--- a/packages/processor/generated/220/tronIngressEgress/palletConfigUpdated.ts
+++ b/packages/processor/generated/220/tronIngressEgress/palletConfigUpdated.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 import { palletCfTronIngressEgressPalletConfigUpdateTron } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronIngressEgressPalletConfigUpdated = z.object({
   update: palletCfTronIngressEgressPalletConfigUpdateTron,
 });
+
+export const tronIngressEgressPalletConfigUpdatedEvent = defineEvent(
+  'TronIngressEgress.PalletConfigUpdated',
+  tronIngressEgressPalletConfigUpdated,
+);

--- a/packages/processor/generated/220/tronIngressEgress/transactionRejectedByBroker.ts
+++ b/packages/processor/generated/220/tronIngressEgress/transactionRejectedByBroker.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { cfChainsEvmDepositDetails } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronIngressEgressTransactionRejectedByBroker = z.object({
   broadcastId: z.number(),
   txId: cfChainsEvmDepositDetails,
 });
+
+export const tronIngressEgressTransactionRejectedByBrokerEvent = defineEvent(
+  'TronIngressEgress.TransactionRejectedByBroker',
+  tronIngressEgressTransactionRejectedByBroker,
+);

--- a/packages/processor/generated/220/tronIngressEgress/transactionRejectionFailed.ts
+++ b/packages/processor/generated/220/tronIngressEgress/transactionRejectionFailed.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 import { cfChainsEvmDepositDetails } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronIngressEgressTransactionRejectionFailed = z.object({
   txId: cfChainsEvmDepositDetails,
 });
+
+export const tronIngressEgressTransactionRejectionFailedEvent = defineEvent(
+  'TronIngressEgress.TransactionRejectionFailed',
+  tronIngressEgressTransactionRejectionFailed,
+);

--- a/packages/processor/generated/220/tronIngressEgress/transactionRejectionRequestExpired.ts
+++ b/packages/processor/generated/220/tronIngressEgress/transactionRejectionRequestExpired.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { accountId, hexString } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronIngressEgressTransactionRejectionRequestExpired = z.object({
   accountId,
   txId: hexString,
 });
+
+export const tronIngressEgressTransactionRejectionRequestExpiredEvent = defineEvent(
+  'TronIngressEgress.TransactionRejectionRequestExpired',
+  tronIngressEgressTransactionRejectionRequestExpired,
+);

--- a/packages/processor/generated/220/tronIngressEgress/transactionRejectionRequestReceived.ts
+++ b/packages/processor/generated/220/tronIngressEgress/transactionRejectionRequestReceived.ts
@@ -1,8 +1,14 @@
 import { z } from 'zod';
 import { accountId, hexString } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronIngressEgressTransactionRejectionRequestReceived = z.object({
   accountId,
   txId: hexString,
   expiresAt: z.number(),
 });
+
+export const tronIngressEgressTransactionRejectionRequestReceivedEvent = defineEvent(
+  'TronIngressEgress.TransactionRejectionRequestReceived',
+  tronIngressEgressTransactionRejectionRequestReceived,
+);

--- a/packages/processor/generated/220/tronIngressEgress/transferFallbackRequested.ts
+++ b/packages/processor/generated/220/tronIngressEgress/transferFallbackRequested.ts
@@ -5,6 +5,7 @@ import {
   hexString,
   numberOrHex,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronIngressEgressTransferFallbackRequested = z.object({
   asset: cfPrimitivesChainsAssetsTronAsset,
@@ -13,3 +14,8 @@ export const tronIngressEgressTransferFallbackRequested = z.object({
   broadcastId: z.number(),
   egressDetails: cfTraitsScheduledEgressDetailsTron.nullish(),
 });
+
+export const tronIngressEgressTransferFallbackRequestedEvent = defineEvent(
+  'TronIngressEgress.TransferFallbackRequested',
+  tronIngressEgressTransferFallbackRequested,
+);

--- a/packages/processor/generated/220/tronIngressEgress/unknownAffiliate.ts
+++ b/packages/processor/generated/220/tronIngressEgress/unknownAffiliate.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { accountId } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronIngressEgressUnknownAffiliate = z.object({
   brokerId: accountId,
   shortAffiliateId: z.number(),
 });
+
+export const tronIngressEgressUnknownAffiliateEvent = defineEvent(
+  'TronIngressEgress.UnknownAffiliate',
+  tronIngressEgressUnknownAffiliate,
+);

--- a/packages/processor/generated/220/tronIngressEgress/unknownBroker.ts
+++ b/packages/processor/generated/220/tronIngressEgress/unknownBroker.ts
@@ -1,4 +1,10 @@
 import { z } from 'zod';
 import { accountId } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronIngressEgressUnknownBroker = z.object({ brokerId: accountId });
+
+export const tronIngressEgressUnknownBrokerEvent = defineEvent(
+  'TronIngressEgress.UnknownBroker',
+  tronIngressEgressUnknownBroker,
+);

--- a/packages/processor/generated/220/tronIngressEgress/utxoConsolidation.ts
+++ b/packages/processor/generated/220/tronIngressEgress/utxoConsolidation.ts
@@ -1,3 +1,9 @@
 import { z } from 'zod';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronIngressEgressUtxoConsolidation = z.object({ broadcastId: z.number() });
+
+export const tronIngressEgressUtxoConsolidationEvent = defineEvent(
+  'TronIngressEgress.UtxoConsolidation',
+  tronIngressEgressUtxoConsolidation,
+);

--- a/packages/processor/generated/220/tronVault/activationTxFailedAwaitingGovernance.ts
+++ b/packages/processor/generated/220/tronVault/activationTxFailedAwaitingGovernance.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 import { cfChainsEvmAggKey } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronVaultActivationTxFailedAwaitingGovernance = z.object({
   newPublicKey: cfChainsEvmAggKey,
 });
+
+export const tronVaultActivationTxFailedAwaitingGovernanceEvent = defineEvent(
+  'TronVault.ActivationTxFailedAwaitingGovernance',
+  tronVaultActivationTxFailedAwaitingGovernance,
+);

--- a/packages/processor/generated/220/tronVault/awaitingGovernanceActivation.ts
+++ b/packages/processor/generated/220/tronVault/awaitingGovernanceActivation.ts
@@ -1,4 +1,10 @@
 import { z } from 'zod';
 import { cfChainsEvmAggKey } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronVaultAwaitingGovernanceActivation = z.object({ newPublicKey: cfChainsEvmAggKey });
+
+export const tronVaultAwaitingGovernanceActivationEvent = defineEvent(
+  'TronVault.AwaitingGovernanceActivation',
+  tronVaultAwaitingGovernanceActivation,
+);

--- a/packages/processor/generated/220/tronVault/chainInitialized.ts
+++ b/packages/processor/generated/220/tronVault/chainInitialized.ts
@@ -1,3 +1,9 @@
 import { z } from 'zod';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronVaultChainInitialized = z.null();
+
+export const tronVaultChainInitializedEvent = defineEvent(
+  'TronVault.ChainInitialized',
+  tronVaultChainInitialized,
+);

--- a/packages/processor/generated/220/tronVault/vaultActivationCompleted.ts
+++ b/packages/processor/generated/220/tronVault/vaultActivationCompleted.ts
@@ -1,3 +1,9 @@
 import { z } from 'zod';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronVaultVaultActivationCompleted = z.null();
+
+export const tronVaultVaultActivationCompletedEvent = defineEvent(
+  'TronVault.VaultActivationCompleted',
+  tronVaultVaultActivationCompleted,
+);

--- a/packages/processor/generated/220/tronVault/vaultRotatedExternally.ts
+++ b/packages/processor/generated/220/tronVault/vaultRotatedExternally.ts
@@ -1,4 +1,10 @@
 import { z } from 'zod';
 import { cfChainsEvmAggKey } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const tronVaultVaultRotatedExternally = cfChainsEvmAggKey;
+
+export const tronVaultVaultRotatedExternallyEvent = defineEvent(
+  'TronVault.VaultRotatedExternally',
+  tronVaultVaultRotatedExternally,
+);

--- a/packages/processor/generated/220/validator/witnessingTaskRestarted.ts
+++ b/packages/processor/generated/220/validator/witnessingTaskRestarted.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { accountId, cfPrimitivesWitnessingTaskName } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const validatorWitnessingTaskRestarted = z.object({
   task: cfPrimitivesWitnessingTaskName,
   reporter: accountId,
 });
+
+export const validatorWitnessingTaskRestartedEvent = defineEvent(
+  'Validator.WitnessingTaskRestarted',
+  validatorWitnessingTaskRestarted,
+);

--- a/packages/processor/package.json
+++ b/packages/processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainflip/processor",
-  "version": "2.2.0-alpha.4",
+  "version": "2.2.0-alpha.5",
   "description": "",
   "type": "module",
   "keywords": [],

--- a/packages/processor/src/codegen/CodeGenerator.ts
+++ b/packages/processor/src/codegen/CodeGenerator.ts
@@ -316,4 +316,23 @@ export default class CodeGenerator extends BaseCodeGenerator {
   protected override getGlobalImports(): string[] {
     return ["import { z } from 'zod';"];
   }
+
+  protected override itemExports(
+    name: string,
+    code: CodegenResult,
+    parserName: string,
+  ): Map<string, CodegenResult> {
+    const exports = new Map([[name, code]]);
+    // Emit a typed event descriptor alongside the bare schema:
+    //   export const <name>Event = defineEvent('Pallet.Event', <name>);
+    // The descriptor references the schema (same file) textually, so it carries
+    // no dependency of its own; only `defineEvent` needs importing.
+    exports.set(
+      `${name}Event`,
+      new Code(`defineEvent('${parserName}', ${name})`, [
+        new Identifier('defineEvent', '@chainflip/processor/event'),
+      ]),
+    );
+    return exports;
+  }
 }

--- a/packages/processor/src/codegen/__tests__/CodeGenerator.test.ts
+++ b/packages/processor/src/codegen/__tests__/CodeGenerator.test.ts
@@ -322,8 +322,11 @@ describe(CodeGenerator, () => {
           "topLevelDir/palletOne/eventOne.ts",
           "import { z } from 'zod';
       import { reusedStruct } from '../common';
+      import { defineEvent } from '@chainflip/processor/event';
 
       export const palletOneEventOne = reusedStruct;
+
+      export const palletOneEventOneEvent = defineEvent('PalletOne.EventOne', palletOneEventOne);
       ",
           "utf8",
         ],

--- a/packages/processor/src/codegen/__tests__/__snapshots__/CodeGenerator.test.ts.snap
+++ b/packages/processor/src/codegen/__tests__/__snapshots__/CodeGenerator.test.ts.snap
@@ -3,8 +3,11 @@
 exports[`CodeGenerator > filters on selected events > EventOne 1`] = `
 "import { z } from 'zod';
 import { myEnum } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const enumsEventOne = myEnum;
+
+export const enumsEventOneEvent = defineEvent('Enums.EventOne', enumsEventOne);
 "
 `;
 
@@ -21,23 +24,35 @@ export const myEnum = simpleEnum(['Flip', 'Usdc', 'Eth']);
 exports[`CodeGenerator > generates a lot of stuff > AccountId32 1`] = `
 "import { z } from 'zod';
 import { accountId } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const primitivesAccountId32 = accountId;
+
+export const primitivesAccountId32Event = defineEvent(
+  'Primitives.AccountId32',
+  primitivesAccountId32,
+);
 "
 `;
 
 exports[`CodeGenerator > generates a lot of stuff > Bytes 1`] = `
 "import { z } from 'zod';
 import { hexString } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const primitivesBytes = hexString;
+
+export const primitivesBytesEvent = defineEvent('Primitives.Bytes', primitivesBytes);
 "
 `;
 
 exports[`CodeGenerator > generates a lot of stuff > Call 1`] = `
 "import { z } from 'zod';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const primitivesCall = z.unknown();
+
+export const primitivesCallEvent = defineEvent('Primitives.Call', primitivesCall);
 "
 `;
 
@@ -51,6 +66,7 @@ import {
   moneySymbol,
   numberOrHex,
 } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const structsEventOne = z.object({
   i8: z.number(),
@@ -97,59 +113,82 @@ export const structsEventOne = z.object({
   flattenedEnumThing: enumWithFlattenedField,
   arrayOfIdentifiers: z.array(moneySymbol),
 });
+
+export const structsEventOneEvent = defineEvent('Structs.EventOne', structsEventOne);
 "
 `;
 
 exports[`CodeGenerator > generates a lot of stuff > EventOne 2`] = `
 "import { z } from 'zod';
 import { myEnum } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const enumsEventOne = myEnum;
+
+export const enumsEventOneEvent = defineEvent('Enums.EventOne', enumsEventOne);
 "
 `;
 
 exports[`CodeGenerator > generates a lot of stuff > H160 1`] = `
 "import { z } from 'zod';
 import { hexString } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const primitivesH160 = hexString;
+
+export const primitivesH160Event = defineEvent('Primitives.H160', primitivesH160);
 "
 `;
 
 exports[`CodeGenerator > generates a lot of stuff > H256 1`] = `
 "import { z } from 'zod';
 import { hexString } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const primitivesH256 = hexString;
+
+export const primitivesH256Event = defineEvent('Primitives.H256', primitivesH256);
 "
 `;
 
 exports[`CodeGenerator > generates a lot of stuff > Percent 1`] = `
 "import { z } from 'zod';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const primitivesPercent = z.number();
+
+export const primitivesPercentEvent = defineEvent('Primitives.Percent', primitivesPercent);
 "
 `;
 
 exports[`CodeGenerator > generates a lot of stuff > Permill 1`] = `
 "import { z } from 'zod';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const primitivesPermill = z.number();
+
+export const primitivesPermillEvent = defineEvent('Primitives.Permill', primitivesPermill);
 "
 `;
 
 exports[`CodeGenerator > generates a lot of stuff > U256 1`] = `
 "import { z } from 'zod';
 import { numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const primitivesU256 = numberOrHex;
+
+export const primitivesU256Event = defineEvent('Primitives.U256', primitivesU256);
 "
 `;
 
 exports[`CodeGenerator > generates a lot of stuff > bool 1`] = `
 "import { z } from 'zod';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const primitivesBool = z.boolean();
+
+export const primitivesBoolEvent = defineEvent('Primitives.bool', primitivesBool);
 "
 `;
 
@@ -213,82 +252,118 @@ export const myEnum = z.discriminatedUnion('__kind', [
 
 exports[`CodeGenerator > generates a lot of stuff > i8 1`] = `
 "import { z } from 'zod';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const primitivesI8 = z.number();
+
+export const primitivesI8Event = defineEvent('Primitives.i8', primitivesI8);
 "
 `;
 
 exports[`CodeGenerator > generates a lot of stuff > i16 1`] = `
 "import { z } from 'zod';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const primitivesI16 = z.number();
+
+export const primitivesI16Event = defineEvent('Primitives.i16', primitivesI16);
 "
 `;
 
 exports[`CodeGenerator > generates a lot of stuff > i32 1`] = `
 "import { z } from 'zod';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const primitivesI32 = z.number();
+
+export const primitivesI32Event = defineEvent('Primitives.i32', primitivesI32);
 "
 `;
 
 exports[`CodeGenerator > generates a lot of stuff > null 1`] = `
 "import { z } from 'zod';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const primitivesNull = z.null();
+
+export const primitivesNullEvent = defineEvent('Primitives.null', primitivesNull);
 "
 `;
 
 exports[`CodeGenerator > generates a lot of stuff > u8 1`] = `
 "import { z } from 'zod';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const primitivesU8 = z.number();
+
+export const primitivesU8Event = defineEvent('Primitives.u8', primitivesU8);
 "
 `;
 
 exports[`CodeGenerator > generates a lot of stuff > u16 1`] = `
 "import { z } from 'zod';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const primitivesU16 = z.number();
+
+export const primitivesU16Event = defineEvent('Primitives.u16', primitivesU16);
 "
 `;
 
 exports[`CodeGenerator > generates a lot of stuff > u32 1`] = `
 "import { z } from 'zod';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const primitivesU32 = z.number();
+
+export const primitivesU32Event = defineEvent('Primitives.u32', primitivesU32);
 "
 `;
 
 exports[`CodeGenerator > generates a lot of stuff > u64 1`] = `
 "import { z } from 'zod';
 import { numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const primitivesU64 = numberOrHex;
+
+export const primitivesU64Event = defineEvent('Primitives.u64', primitivesU64);
 "
 `;
 
 exports[`CodeGenerator > generates a lot of stuff > u128 1`] = `
 "import { z } from 'zod';
 import { numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const primitivesU128 = numberOrHex;
+
+export const primitivesU128Event = defineEvent('Primitives.u128', primitivesU128);
 "
 `;
 
 exports[`CodeGenerator > generates a named struct once > AnotherEvent 1`] = `
 "import { z } from 'zod';
 import { reusedStruct } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const palletOneAnotherEvent = reusedStruct;
+
+export const palletOneAnotherEventEvent = defineEvent(
+  'PalletOne.AnotherEvent',
+  palletOneAnotherEvent,
+);
 "
 `;
 
 exports[`CodeGenerator > generates a named struct once > EventOne 1`] = `
 "import { z } from 'zod';
 import { reusedStruct } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const palletOneEventOne = reusedStruct;
+
+export const palletOneEventOneEvent = defineEvent('PalletOne.EventOne', palletOneEventOne);
 "
 `;
 
@@ -302,8 +377,11 @@ export const reusedStruct = z.object({ field: z.number() });
 exports[`CodeGenerator > generates the encoded address enum > EventOne 1`] = `
 "import { z } from 'zod';
 import { cfChainsAddressEncodedAddress } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const palletOneEventOne = cfChainsAddressEncodedAddress;
+
+export const palletOneEventOneEvent = defineEvent('PalletOne.EventOne', palletOneEventOne);
 "
 `;
 

--- a/packages/processor/src/processor/__tests__/event.test.ts
+++ b/packages/processor/src/processor/__tests__/event.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { defineEvent } from '../event';
+
+const schema = z.object({ swapRequestId: z.number(), amount: z.number() });
+
+describe('defineEvent', () => {
+  it('bundles the name and schema', () => {
+    const event = defineEvent('Swapping.SwapExecuted', schema);
+    expect(event.name).toBe('Swapping.SwapExecuted');
+    expect(event.schema).toBe(schema);
+    expect(event.schema.parse({ swapRequestId: 1, amount: 2 })).toEqual({
+      swapRequestId: 1,
+      amount: 2,
+    });
+  });
+
+  it('preserves the name through .refine() and narrows the schema', () => {
+    const event = defineEvent('Swapping.SwapExecuted', schema).refine((e) => e.swapRequestId === 7);
+
+    expect(event.name).toBe('Swapping.SwapExecuted');
+    expect(event.schema.safeParse({ swapRequestId: 7, amount: 2 }).success).toBe(true);
+    expect(event.schema.safeParse({ swapRequestId: 8, amount: 2 }).success).toBe(false);
+  });
+
+  it('keeps the name across chained .refine() calls', () => {
+    const event = defineEvent('Swapping.SwapExecuted', schema)
+      .refine((e) => e.swapRequestId === 7)
+      .refine((e) => e.amount > 0);
+
+    expect(event.name).toBe('Swapping.SwapExecuted');
+    expect(event.schema.safeParse({ swapRequestId: 7, amount: 2 }).success).toBe(true);
+    expect(event.schema.safeParse({ swapRequestId: 7, amount: 0 }).success).toBe(false);
+  });
+});

--- a/packages/processor/src/processor/event.ts
+++ b/packages/processor/src/processor/event.ts
@@ -1,0 +1,32 @@
+import { type z } from 'zod';
+
+/**
+ * A generated event: its on-chain `Pallet.Event` name bundled with the zod schema
+ * for its payload. Built by {@link defineEvent} in codegen, one per event, alongside
+ * the bare schema. Use `.refine(...)` to narrow to events whose decoded payload
+ * satisfies a predicate — it preserves the name, so the two never drift apart.
+ */
+export type EventDescriptor<N extends string = string, Z extends z.ZodTypeAny = z.ZodTypeAny> = {
+  /** On-chain event name, `Pallet.Event`. */
+  readonly name: N;
+  /** The event payload schema (the bare generated schema, possibly refined via `.refine`). */
+  readonly schema: Z;
+  /** Narrow to events whose decoded payload satisfies `refinement` (wraps zod `.refine`,
+   *  so the predicate may return any truthy/falsy value, matching zod's `.refine`). */
+  refine(refinement: (data: z.infer<Z>) => unknown): EventDescriptor<N, z.ZodEffects<Z>>;
+};
+
+/**
+ * Construct an {@link EventDescriptor}. `z.infer<z.ZodEffects<Z>>` equals `z.infer<Z>`,
+ * so the decoded payload type is preserved across any number of chained `.refine()` calls.
+ */
+export function defineEvent<const N extends string, Z extends z.ZodTypeAny>(
+  name: N,
+  schema: Z,
+): EventDescriptor<N, Z> {
+  return {
+    name,
+    schema,
+    refine: (refinement) => defineEvent(name, schema.refine(refinement)),
+  };
+}

--- a/packages/processor/tsdown.config.mjs
+++ b/packages/processor/tsdown.config.mjs
@@ -9,6 +9,11 @@ const baseConfig = defineConfig({
   format: ['esm', 'cjs'],
   target: 'es2022',
   skipNodeModulesBundle: true,
+  // The generated event files self-import `@chainflip/processor/event` so consumers
+  // resolve it from the installed package. A tsconfig path alias lets `tsc --noEmit`
+  // resolve it from source pre-build; keep it external here so the bundler doesn't
+  // rewrite it to a relative source path via that alias.
+  external: [/^@chainflip\/processor\//],
 });
 
 const BUILD_TARGET = process.env.BUILD_TARGET;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,7 @@
       "@/chainspec/*": ["./packages/chainspec/src/*"],
       "@/scale/*": ["./packages/scale/src/*"],
       "@/testing": ["./packages/testing/src/index"],
+      "@chainflip/processor/event": ["./packages/processor/src/processor/event"],
     },
 
     /* Modules */


### PR DESCRIPTION
Adds an extra object to the generated schema files that links the event data to the even name. We can use this in the bouncer to simplify the tests and detect breaking changes to event names.
This PR was made with AI, please review with care. Lmk if there is a better way of doing this.