### PR TITLE
feat(rpc): add rewards estimate rpc

### DIFF
--- a/packages/rpc/src/__tests__/HttpClient.test.ts
+++ b/packages/rpc/src/__tests__/HttpClient.test.ts
@@ -35,6 +35,7 @@ import {
   poolOrders,
   poolPriceV2,
   poolsEnvironment,
+  rewardDistributionEstimate,
   runtimeVersion,
   safeModeStatuses,
   supportedAssets,
@@ -106,6 +107,7 @@ describe(HttpClient, () => {
         "cf_pool_price_v2",
         "cf_pools_environment",
         "cf_request_swap_parameter_encoding",
+        "cf_reward_distribution_estimate",
         "cf_safe_mode_statuses",
         "cf_supported_assets",
         "cf_swap_rate",
@@ -488,6 +490,8 @@ describe(HttpClient, () => {
           return respond(loanAccounts220);
         case 'cf_all_loans':
           return respond(allLoans);
+        case 'cf_reward_distribution_estimate':
+          return respond(rewardDistributionEstimate);
         case 'cf_all_account_infos':
           return respond(Object.values(accounts));
         case 'cf_lending_pool_supply_balances':
@@ -608,6 +612,7 @@ describe(HttpClient, () => {
       ['cf_lending_pool_supply_balances'],
       ['cf_all_loans'],
       ['cf_all_account_infos'],
+      ['cf_reward_distribution_estimate'],
     ] as [SimpleRpcMethod, string?][])('handles %s', async (method, id) => {
       if (id) vi.spyOn(crypto, 'randomUUID').mockImplementationOnce(() => id as any);
       expect(await client.sendRequest(method)).toMatchSnapshot();

--- a/packages/rpc/src/__tests__/__snapshots__/HttpClient.test.ts.snap
+++ b/packages/rpc/src/__tests__/__snapshots__/HttpClient.test.ts.snap
@@ -2703,6 +2703,44 @@ exports[`HttpClient > with server > handles cf_loan_accounts 1`] = `
 ]
 `;
 
+exports[`HttpClient > with server > handles cf_reward_distribution_estimate 1`] = `
+{
+  "authority_count": 3,
+  "bond": 100000000000000000000000n,
+  "current_block": 2000000n,
+  "current_epoch_started_at": 1900000n,
+  "epoch_duration": 43200n,
+  "epoch_index": 1234n,
+  "per_authority_share": 13000000000000000000n,
+  "reward_pool": [
+    {
+      "account": "cFKzr7DwLCRtSkou5H5moKri7g9WwJ4tAbVJv6dZGhLb811Tc",
+      "bid": 500000000000000000000n,
+      "bond": 100000000000000000000000n,
+      "delegated_to": "cFKvKKCcScNcWyrJRASocm7vZq5vU8QpQhqdVGU8PnMEwgud5",
+      "managed_by": "cFNzMM63izeZ2zqKiUpUVWLEd6YqzbVEAHgPtgHLDtAVG4Hmv",
+      "reward": 13000000000000000000n,
+      "role": "operator",
+    },
+    {
+      "account": "cFJ6qQZ3ybhMDPt7KXDUUj3aLC2DXaPm8rCLCfLEsyMRH2AXK",
+      "bid": 1000000000n,
+      "bond": 100000000000000000000000n,
+      "reward": 13000000000000000000n,
+      "role": "validator",
+    },
+    {
+      "account": "cFJjZKzA5rUTb9qkZMGfec7piCpiAQKr15B4nALzriMGQL8BE",
+      "bid": 0n,
+      "bond": 0n,
+      "reward": 0n,
+      "role": "unregistered",
+    },
+  ],
+  "total_rewards": 10000000000000000000000n,
+}
+`;
+
 exports[`HttpClient > with server > handles cf_safe_mode_statuses 1`] = `
 {
   "arbitrum_elections": {

--- a/packages/rpc/src/__tests__/fixtures.ts
+++ b/packages/rpc/src/__tests__/fixtures.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import {
   cfAllLoans,
+  cfRewardDistributionEstimate,
   type broker,
   type brokerRequestAccountCreationDepositAddress,
   type brokerRequestSwapDepositAddress,
@@ -2160,3 +2161,39 @@ export const allLoans: z.input<typeof cfAllLoans> = [
     principal_amount: '0x5F5E100',
   },
 ];
+
+export const rewardDistributionEstimate: z.input<typeof cfRewardDistributionEstimate> = {
+  epoch_index: 1234,
+  current_block: '0x1e8480',
+  current_epoch_started_at: 1900000,
+  epoch_duration: 43200,
+  bond: '0x152d02c7e14af6800000',
+  authority_count: 3,
+  total_rewards: '0x21e19e0c9bab2400000',
+  per_authority_share: '0xb469471f80140000',
+  reward_pool: [
+    {
+      account: VALIDATOR_ACCOUNT_ID,
+      bid: '0x1b1ae4d6e2ef500000',
+      bond: '0x152d02c7e14af6800000',
+      reward: '0xb469471f80140000',
+      role: 'operator',
+      managed_by: DELEGATOR_ACCOUNT_ID,
+      delegated_to: DELEGATOR_ACCOUNT_ID2,
+    },
+    {
+      account: VALIDATOR_ACCOUNT_ID2,
+      bid: 1000000000,
+      bond: '0x152d02c7e14af6800000',
+      reward: '0xb469471f80140000',
+      role: 'validator',
+    },
+    {
+      account: BROKER_ACCOUNT_ID,
+      bid: 0,
+      bond: 0,
+      reward: 0,
+      role: 'unregistered',
+    },
+  ],
+};

--- a/packages/rpc/src/__tests__/parsers.test.ts
+++ b/packages/rpc/src/__tests__/parsers.test.ts
@@ -24,6 +24,7 @@ import {
   cfIngressEgressEvents,
   cfAllLoans,
   cfAllAccountInfos,
+  cfRewardDistributionEstimate,
 } from '../parsers';
 import {
   accounts,
@@ -38,6 +39,7 @@ import {
   loanAccounts220,
   monitoringSimulateAuction,
   poolOrders,
+  rewardDistributionEstimate,
   safeModeStatuses,
   tradingStrategies,
   tradingStrategiesLimits,
@@ -4073,6 +4075,48 @@ describe('parsers', () => {
 
     it('parses an empty list', () => {
       expect(cfAllAccountInfos.parse([])).toEqual([]);
+    });
+  });
+
+  describe('cfRewardDistributionEstimate', () => {
+    it('parses the reward distribution estimate response', () => {
+      expect(cfRewardDistributionEstimate.parse(rewardDistributionEstimate)).toMatchInlineSnapshot(`
+        {
+          "authority_count": 3,
+          "bond": 100000000000000000000000n,
+          "current_block": 2000000n,
+          "current_epoch_started_at": 1900000n,
+          "epoch_duration": 43200n,
+          "epoch_index": 1234n,
+          "per_authority_share": 13000000000000000000n,
+          "reward_pool": [
+            {
+              "account": "cFKzr7DwLCRtSkou5H5moKri7g9WwJ4tAbVJv6dZGhLb811Tc",
+              "bid": 500000000000000000000n,
+              "bond": 100000000000000000000000n,
+              "delegated_to": "cFKvKKCcScNcWyrJRASocm7vZq5vU8QpQhqdVGU8PnMEwgud5",
+              "managed_by": "cFNzMM63izeZ2zqKiUpUVWLEd6YqzbVEAHgPtgHLDtAVG4Hmv",
+              "reward": 13000000000000000000n,
+              "role": "operator",
+            },
+            {
+              "account": "cFJ6qQZ3ybhMDPt7KXDUUj3aLC2DXaPm8rCLCfLEsyMRH2AXK",
+              "bid": 1000000000n,
+              "bond": 100000000000000000000000n,
+              "reward": 13000000000000000000n,
+              "role": "validator",
+            },
+            {
+              "account": "cFJjZKzA5rUTb9qkZMGfec7piCpiAQKr15B4nALzriMGQL8BE",
+              "bid": 0n,
+              "bond": 0n,
+              "reward": 0n,
+              "role": "unregistered",
+            },
+          ],
+          "total_rewards": 10000000000000000000000n,
+        }
+      `);
     });
   });
 });

--- a/packages/rpc/src/common.ts
+++ b/packages/rpc/src/common.ts
@@ -49,6 +49,7 @@ import {
   brokerRequestAccountCreationDepositAddress,
   cfAllLoans,
   cfAllAccountInfos,
+  cfRewardDistributionEstimate,
 } from './parsers';
 
 type Nullish<T> = T | null | undefined;
@@ -241,6 +242,7 @@ export type RpcRequest = WithHash<{
   cf_ingress_egress_events: [chain: Chain];
   cf_all_loans: [];
   cf_all_account_infos: [roles?: Nullish<AccountRole[]>];
+  cf_reward_distribution_estimate: [];
 }> & {
   chain_getBlockHash: [blockHeight?: number];
   broker_request_swap_deposit_address: [
@@ -325,6 +327,7 @@ export const rpcResult = {
   cf_ingress_egress_events: cfIngressEgressEvents,
   cf_all_loans: cfAllLoans,
   cf_all_account_infos: cfAllAccountInfos,
+  cf_reward_distribution_estimate: cfRewardDistributionEstimate,
 } as const satisfies { [K in keyof RpcRequest]: z.ZodTypeAny };
 
 export type RpcMethod = keyof RpcRequest;

--- a/packages/rpc/src/parsers.ts
+++ b/packages/rpc/src/parsers.ts
@@ -981,3 +981,26 @@ export const cfVaultAddresses = z
   });
 
 export const cfAllLoans = z.array(cfLoan);
+
+const AccountRewardRole = z.enum(['unregistered', 'validator', 'operator']);
+
+const accountReward = z.object({
+  account: accountId,
+  bid: numberOrHex,
+  bond: numberOrHex,
+  reward: numberOrHex,
+  role: AccountRewardRole,
+  managed_by: accountId.optional(),
+  delegated_to: accountId.optional(),
+});
+export const cfRewardDistributionEstimate = z.object({
+  epoch_index: numberOrHex,
+  current_block: numberOrHex,
+  current_epoch_started_at: numberOrHex,
+  epoch_duration: numberOrHex,
+  bond: numberOrHex,
+  authority_count: z.number(),
+  total_rewards: numberOrHex,
+  per_authority_share: numberOrHex,
+  reward_pool: z.array(accountReward),
+});

--- a/packages/rpc/src/types.ts
+++ b/packages/rpc/src/types.ts
@@ -41,6 +41,7 @@ export type CfLendingPoolSupplyBalances = RpcResult<'cf_lending_pool_supply_bala
 export type CfVaultAddresses = RpcResult<'cf_get_vault_addresses'>;
 export type CfAllLoans = RpcResult<'cf_all_loans'>;
 export type CfAllAccountInfos = RpcResult<'cf_all_account_infos'>;
+export type CfRewardDistributionEstimate = RpcResult<'cf_reward_distribution_estimate'>;
 
 export type CfAccountInfoResponse = RpcResponse<'cf_account_info'>;
 export type CfAccountsResponse = RpcResponse<'cf_accounts'>;
@@ -82,6 +83,7 @@ export type CfLendingPoolSupplyBalancesResponse = RpcResponse<'cf_lending_pool_s
 export type CfVaultAddressesResponse = RpcResponse<'cf_get_vault_addresses'>;
 export type CfAllLoansResponse = RpcResponse<'cf_all_loans'>;
 export type CfAllAccountInfosResponse = RpcResponse<'cf_all_account_infos'>;
+export type CfRewardDistributionEstimateResponse = RpcResponse<'cf_reward_distribution_estimate'>;
 export type CfUnregisteredAccount = z.output<typeof unregistered>;
 export type CfBrokerAccount = z.output<typeof broker>;
 export type CfValidatorAccount = z.output<typeof validator>;


### PR DESCRIPTION
Adds support for the new `cf_reward_distribution_estimate` RPC: https://github.com/chainflip-io/chainflip-backend/pull/6712